### PR TITLE
In example, display content once decrypted

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -129,16 +129,17 @@ function insertIntoCell(returnedFiles) {
     (child) => child.id,
   );
 
-  returnedFiles.forEach((returnedFile, i) => {
-    Object.entries(returnedFile).forEach(([key, value]) => {
+  returnedFiles.forEach(async (returnedFile, i) => {
+    const returnedFileObj = await returnedFile;
+    Object.entries(returnedFileObj).forEach(([key, value]) => {
       if (!headerIds.includes(key)) {
         return;
       }
       const cell = document.getElementById(`${i}-${key}`);
 
-      if (key === 'data' && returnedFile.type === 'uri') {
+      if (key === 'data' && returnedFileObj.type === 'uri') {
         // Display media
-        const elementType = returnedFile.mimetype.split('/')[0];
+        const elementType = returnedFileObj.mimetype.split('/')[0];
 
         let media;
         if (elementType === 'image') {
@@ -165,7 +166,10 @@ const onReady = async ({ detail: { penumbra } } = { detail: self }) => {
   // Download and decrypt and display in table
   penumbra
     .get(...files)
-    .then((pfiles) => penumbra.getTextOrURI(pfiles))
+    .then((pfiles) => pfiles.map(penumbra.getTextOrURI))
+    // // See https://github.com/transcend-io/penumbra/issues/56
+    // .then((pfiles) => penumbra.getTextOrURI(pfiles))
+    // .then(insertIntoCell);
     .then(insertIntoCell);
 
   const runOnce = {};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ts:lint": "tslint --project .",
     "####### Start #########": "",
     "start": "http-server build -a localhost",
+    "start:example": "npm run build:example && http-server example",
     "####### Testing #######": "",
     "test:interactive": "http-server build -a localhost",
     "airtap:test:interactive": "airtap --local build/src/tests/*.test.js",


### PR DESCRIPTION
- Adds logic to display content when it's decrytped (this should be partially reverted once #56 is complete)
- Adds `npm run start:example` for running locally