### PR TITLE
Updates API reference, adds import instructions, adds table of contents

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,15 +1,15 @@
 {
-    "default": true,
-    "MD004": {
-        "style": "dash"
-    },
-    "MD013": {
-        "line_length": 1e6
-    },
-    "MD029": {
-        "style": "ordered"
-    },
-    "MD033": false,
-    "MD041": false,
-    "MD002": false
+  "default": true,
+  "MD004": {
+    "style": "asterisk"
+  },
+  "MD013": {
+    "line_length": 1e6
+  },
+  "MD029": {
+    "style": "ordered"
+  },
+  "MD033": false,
+  "MD041": false,
+  "MD002": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,7 @@
 {
   "default": true,
   "MD004": {
-    "style": "asterisk"
+    "style": "dash"
   },
   "MD013": {
     "line_length": 1e6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <strong>Fetch and decrypt files in the browser using whatwg streams and web workers.</strong>
   <br /><br />
-  <i>Quickly and efficiently decrypt remote resources in the browser. Display the files in the DOM, or download them with [conflux](https://github.com/trasncend-io/conflux).</i>
+  <i>Quickly and efficiently decrypt remote resources in the browser. Display the files in the DOM, or download them with <a href="https://github.com/trasncend-io/conflux">conflux</a>.</i>
   <br /><br />
   <a href="https://travis-ci.com/transcend-io/penumbra"><img src="https://travis-ci.com/transcend-io/penumbra.svg?branch=master" alt="Build Status"></a>
   <a href="https://snyk.io//test/github/transcend-io/penumbra?targetFile=package.json"><img src="https://snyk.io//test/github/transcend-io/penumbra/badge.svg?targetFile=package.json" alt="Known Vulnerabilities"></a>
@@ -15,6 +15,35 @@
   <a href="https://saucelabs.com/u/penumbra"><img src="https://saucelabs.com/browser-matrix/penumbra.svg?auth=c2b96594999df3d684c9af8d63a0c61e" alt="Sauce Test Status"></a>
 </p>
 <br />
+
+## Contents
+
+<!-- toc -->
+
+* [Usage](#usage)
+  * [Importing Penumbra](#importing-penumbra)
+    * [With NPM](#with-npm)
+    * [Vanilla JS](#vanilla-js)
+  * [.get](#get)
+  * [.save](#save)
+  * [.getBlob](#getblob)
+  * [.getTextOrURI](#gettextoruri)
+  * [.zip](#zip)
+  * [.setWorkerLocation](#setworkerlocation)
+* [Examples](#examples)
+  * [Display encrypted text](#display-encrypted-text)
+  * [Display encrypted image](#display-encrypted-image)
+  * [Download an encrypted file](#download-an-encrypted-file)
+  * [Download many encrypted files](#download-many-encrypted-files)
+* [Advanced](#advanced)
+  * [Prepare connections for file downloads in advance](#prepare-connections-for-file-downloads-in-advance)
+  * [Download Progress Event Emitter](#download-progress-event-emitter)
+  * [Configure worker location](#configure-worker-location)
+  * [Waiting for the `penumbra-ready` event](#waiting-for-the-penumbra-ready-event)
+* [Contributing](#contributing)
+* [Big Thanks](#big-thanks)
+
+<!-- tocstop -->
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ penumbra.setWorkerLocation({decrypt: 'penumbra.decrypt.js'});
 
 ```ts
 const onReady = async ({ detail: { penumbra } } = { detail: self }) => {
-  // await penumbra.get(...);
+  await penumbra.get(...files).then(penumbra.save);
 };
 
 if (!self.penumbra) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <strong>Fetch and decrypt files in the browser using whatwg streams and web workers.</strong>
   <br /><br />
-  <i>Coming soon. This repo is currently a work in progress.</i>
+  <i>Quickly and efficiently decrypt remote resources in the browser. Display the files in the DOM, or download them with [conflux](https://github.com/trasncend-io/conflux).</i>
   <br /><br />
   <a href="https://travis-ci.com/transcend-io/penumbra"><img src="https://travis-ci.com/transcend-io/penumbra.svg?branch=master" alt="Build Status"></a>
   <a href="https://snyk.io//test/github/transcend-io/penumbra?targetFile=package.json"><img src="https://snyk.io//test/github/transcend-io/penumbra/badge.svg?targetFile=package.json" alt="Known Vulnerabilities"></a>
@@ -29,7 +29,7 @@ npm install --save @transcend-io/penumbra
 ```js
 import * as penumbra from '@transcend-io/penumbra'
 
-penumbra.get(files); // ...
+penumbra.get(...files).then(penumbra.save);
 ```
 
 #### Vanilla JS
@@ -37,7 +37,7 @@ penumbra.get(files); // ...
 ```html
 <script src="lib/penumbra.js"></script>
 <script>
-  penumbra.get(files); // ...
+  penumbra.get(...files).then(penumbra.getTextOrURI).then(displayInDOM);
 </script>
 ```
 
@@ -45,26 +45,26 @@ _Check out [this guide](#waiting-for-the-penumbra-ready-event) for asynchornous 
 
 ### .get
 
-Fetch and decrypt remote files
+Fetch and decrypt remote files.
 
 ```ts
-penumbra.get(...resources: RemoteResource[]): Promise<PenumbraFiles[]>
+penumbra.get(...resources: RemoteResource[]): Promise<PenumbraFile[]>
 ```
 
 ### .save
 
-Save files retrieved by Penumbra
+Save files retrieved by Penumbra. Downloads a .zip if there are multiple files.
 
 ```ts
-penumbra.save(data: PenumbraFiles, fileName?: string): Promise<void>
+penumbra.save(data: PenumbraFile[], fileName?: string): Promise<void>
 ```
 
 ### .getBlob
 
-Load files retrieved by Penumbra into memory as a Blob
+Load files retrieved by Penumbra into memory as a Blob.
 
 ```ts
-penumbra.getBlob(data: PenumbraFiles): Promise<Blob>
+penumbra.getBlob(data: PenumbraFile[] | PenumbraFile | ReadableStream, type?: string): Promise<Blob>
 ```
 
 ### .getTextOrURI
@@ -72,20 +72,20 @@ penumbra.getBlob(data: PenumbraFiles): Promise<Blob>
 Get file text (if content is text) or [URI](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) (if content is not viewable).
 
 ```ts
-penumbra.getTextOrURI(data: PenumbraFiles): Promise<{ type: 'text'|'uri', data: string }>
+penumbra.getTextOrURI(data: PenumbraFile[] | PenumbraFile): Promise<{ type: 'text'|'uri', data: string, mimetype: string }>
 ```
 
 ### .zip
 
-Zip files retrieved by Penumbra
+Zip files retrieved by Penumbra.
 
 ```ts
-penumbra.zip(data: PenumbraFiles, compressionLevel?: number): Promise<ReadableStream>
+penumbra.zip(data: PenumbraFile[] | PenumbraFile, compressionLevel?: number): Promise<ReadableStream>
 ```
 
 ### .setWorkerLocation
 
-Configure the location of Penumbra's worker threads
+Configure the location of Penumbra's worker threads.
 
 ```ts
 penumbra.setWorkerLocation(location: WorkerLocationOptions | string): Promise<void>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,28 @@
 
 ### Importing Penumbra
 
-TODO
+#### With NPM
+
+```sh
+npm install --save @transcend-io/penumbra
+```
+
+```js
+import * as penumbra from '@transcend-io/penumbra'
+
+penumbra.get(files); // ...
+```
+
+#### Vanilla JS
+
+```html
+<script src="lib/penumbra.js"></script>
+<script>
+  penumbra.get(files); // ...
+</script>
+```
+
+_Check out [this guide](#waiting-for-the-penumbra-ready-event) for asynchornous loading._
 
 ### .get
 
@@ -68,16 +89,6 @@ Configure the location of Penumbra's worker threads
 
 ```ts
 penumbra.setWorkerLocation(location: WorkerLocationOptions | string): Promise<void>
-```
-
-### `penumbra-ready` event
-
-Listen for this event to know when Penumbra is ready to be used.
-
-```ts
-self.addEventListener('penumbra-ready', async ({ detail: { penumbra } }) => {
-  // await penumbra.get(...);
-});
 ```
 
 ## Examples
@@ -252,6 +263,10 @@ penumbra.setWorkerLocation({decrypt: 'penumbra.decrypt.js'});
 ```
 
 ### Waiting for the `penumbra-ready` event
+
+```html
+<script src="lib/penumbra.js" async defer></script>
+```
 
 ```ts
 const onReady = async ({ detail: { penumbra } } = { detail: self }) => {

--- a/README.md
+++ b/README.md
@@ -16,32 +16,30 @@
 </p>
 <br />
 
-## Contents
-
 <!-- toc -->
 
-* [Usage](#usage)
-  * [Importing Penumbra](#importing-penumbra)
-    * [With NPM](#with-npm)
-    * [Vanilla JS](#vanilla-js)
-  * [.get](#get)
-  * [.save](#save)
-  * [.getBlob](#getblob)
-  * [.getTextOrURI](#gettextoruri)
-  * [.zip](#zip)
-  * [.setWorkerLocation](#setworkerlocation)
-* [Examples](#examples)
-  * [Display encrypted text](#display-encrypted-text)
-  * [Display encrypted image](#display-encrypted-image)
-  * [Download an encrypted file](#download-an-encrypted-file)
-  * [Download many encrypted files](#download-many-encrypted-files)
-* [Advanced](#advanced)
-  * [Prepare connections for file downloads in advance](#prepare-connections-for-file-downloads-in-advance)
-  * [Download Progress Event Emitter](#download-progress-event-emitter)
-  * [Configure worker location](#configure-worker-location)
-  * [Waiting for the `penumbra-ready` event](#waiting-for-the-penumbra-ready-event)
-* [Contributing](#contributing)
-* [Big Thanks](#big-thanks)
+- [Usage](#usage)
+  - [Importing Penumbra](#importing-penumbra)
+    - [With NPM](#with-npm)
+    - [Vanilla JS](#vanilla-js)
+  - [.get](#get)
+  - [.save](#save)
+  - [.getBlob](#getblob)
+  - [.getTextOrURI](#gettextoruri)
+  - [.zip](#zip)
+  - [.setWorkerLocation](#setworkerlocation)
+- [Examples](#examples)
+  - [Display encrypted text](#display-encrypted-text)
+  - [Display encrypted image](#display-encrypted-image)
+  - [Download an encrypted file](#download-an-encrypted-file)
+  - [Download many encrypted files](#download-many-encrypted-files)
+- [Advanced](#advanced)
+  - [Prepare connections for file downloads in advance](#prepare-connections-for-file-downloads-in-advance)
+  - [Download Progress Event Emitter](#download-progress-event-emitter)
+  - [Configure worker location](#configure-worker-location)
+  - [Waiting for the `penumbra-ready` event](#waiting-for-the-penumbra-ready-event)
+- [Contributing](#contributing)
+- [Big Thanks](#big-thanks)
 
 <!-- tocstop -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,6 +1481,15 @@
         "ansi-wrap": "0.1.0"
       }
     },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1762,6 +1771,15 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "dev": true,
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2990,6 +3008,12 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3154,6 +3178,23 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "configstore": {
@@ -3705,6 +3746,12 @@
           "dev": true
         }
       }
+    },
+    "diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -4320,6 +4367,57 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         }
       }
     },
@@ -5756,11 +5854,46 @@
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
+    "gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "dev": true,
+      "requires": {
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
     },
     "gulp-mocha": {
       "version": "6.0.0",
@@ -6989,6 +7122,15 @@
         "package-json": "^4.0.0"
       }
     },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "^0.1.0"
+      }
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -7015,6 +7157,47 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -7080,6 +7263,12 @@
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -7121,6 +7310,25 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -7227,6 +7435,46 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+      "dev": true
+    },
+    "markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "diacritics-map": "^0.1.0",
+        "gray-matter": "^2.1.0",
+        "lazy-cache": "^2.0.2",
+        "list-item": "^1.1.1",
+        "markdown-link": "^0.1.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "object.pick": "^1.2.0",
+        "remarkable": "^1.7.1",
+        "repeat-string": "^1.6.1",
+        "strip-color": "^0.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -9197,6 +9445,25 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9472,6 +9739,16 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
       }
     },
     "remote-web-streams": {
@@ -9893,6 +10170,15 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "^0.3.0"
+      }
     },
     "set-value": {
       "version": "2.0.1",
@@ -10557,6 +10843,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -11074,6 +11366,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
+    "toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
       "dev": true
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "check:deps:interactive": "npm-check -u",
     "####### Build #######": "",
     "clean": "rimraf build",
-    "build": "npm run clean && mkdir -p build && webpack && cp src/demo/* build/",
+    "build": "npm run clean && mkdir -p build && webpack && cp src/demo/* build/ && npm run build:markdown",
+    "build:markdown": "markdown-toc -i --bullets '*' README.md",
     "build:watch": "tsc --watch",
     "webpack:watch": "npm run clean && webpack --watch",
     "build:example": "cp -a build example"
@@ -85,6 +86,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "fetch-mock": "^7.3.6",
     "http-server": "^0.11.1",
+    "markdown-toc": "^1.2.0",
     "npm-check": "^5.9.0",
     "nyc": "^14.1.1",
     "prettier": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "####### Build #######": "",
     "clean": "rimraf build",
     "build": "npm run clean && mkdir -p build && webpack && cp src/demo/* build/ && npm run build:markdown",
-    "build:markdown": "markdown-toc -i --bullets '*' README.md",
+    "build:markdown": "markdown-toc -i --bullets '—' README.md && sed -i -e 's/—/-/g' README.md && rm README.md-e",
     "build:watch": "tsc --watch",
     "webpack:watch": "npm run clean && webpack --watch",
     "build:example": "cp -a build example"


### PR DESCRIPTION
_Note: `markdown-toc` is broken for "dash" bullet styles_. 

~Putting this on WIP until that is resolved https://github.com/jonschlinkert/markdown-toc/issues/146~ see https://github.com/transcend-io/penumbra/pull/59/commits/1e366b6ca7fbcc92777fb2e5b8ffe8fdedbedeb2 where we use a slightly different hyphen char