### PR TITLE
Switch to TS native for ESM/CJS imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.7.3",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
-  "types": "build/src/index.d.ts",
+  "types": "build/types/src/index.d.ts",
   "directories": {
     "example": "example"
   },
@@ -29,9 +29,9 @@
     "check:deps:interactive": "npm-check -u",
     "####### Build #######": "",
     "clean": "rimraf build && rimraf coverage",
-    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && yarn build:markdown",
+    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && yarn build:types && yarn build:markdown",
+    "build:types": "tsc",
     "build:markdown": "markdown-toc -i --bullets '—' README.md && sed -i -e 's/—/-/g' README.md && rm -f README.md-e",
-    "build:watch": "tsc --watch",
     "build:example": "rimraf example/build && cp -a build example",
     "webpack:watch": "yarn clean && webpack --watch"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@transcend-io/penumbra",
   "version": "4.7.3",
   "description": "Encrypt/decrypt anything in the browser using streams on background threads.",
-  "main": "build/penumbra.js",
+  "main": "src/index.ts",
   "directories": {
     "example": "example"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@transcend-io/penumbra",
   "version": "4.7.3",
-  "description": "Crypto streams for the browser.",
+  "description": "Encrypt/decrypt anything in the browser using streams on background threads.",
   "main": "build/penumbra.js",
-  "types": "build/types/src/index.d.ts",
   "directories": {
     "example": "example"
   },
@@ -29,8 +28,7 @@
     "check:deps:interactive": "npm-check -u",
     "####### Build #######": "",
     "clean": "rimraf build && rimraf coverage",
-    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && yarn build:types && yarn build:markdown",
-    "build:types": "tsc",
+    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && yarn build:markdown",
     "build:markdown": "markdown-toc -i --bullets '—' README.md && sed -i -e 's/—/-/g' README.md && rm -f README.md-e",
     "build:example": "rimraf example/build && cp -a build example",
     "webpack:watch": "yarn clean && webpack --watch"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "build/src/index.d.ts",
@@ -29,7 +29,7 @@
     "check:deps:interactive": "npm-check -u",
     "####### Build #######": "",
     "clean": "rimraf build && rimraf coverage",
-    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && tsc --declaration && yarn build:markdown",
+    "build": "yarn clean && mkdir -p build && webpack && cp src/demo/* build/ && yarn build:markdown",
     "build:markdown": "markdown-toc -i --bullets '—' README.md && sed -i -e 's/—/-/g' README.md && rm -f README.md-e",
     "build:watch": "tsc --watch",
     "build:example": "rimraf example/build && cp -a build example",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "compileOnSave": true,
+  "compileOnSave": false,
   "compilerOptions": {
     "incremental": true,
     "target": "es2020",
@@ -8,6 +8,8 @@
     "allowJs": false,
     "declaration": true,
     "declarationMap": true,
+    "declarationDir": "build/types",
+    "emitDeclarationOnly": true, // Only used for linting and d.ts declaration. Not Babel builds
     "sourceMap": true,
     "removeComments": false,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "compileOnSave": false,
+  "compileOnSave": true,
   "compilerOptions": {
     "incremental": true,
     "target": "es2020",
@@ -8,8 +8,6 @@
     "allowJs": false,
     "declaration": true,
     "declarationMap": true,
-    "declarationDir": "build/types",
-    "emitDeclarationOnly": true, // Only used for linting and d.ts declaration. Not Babel builds
     "sourceMap": true,
     "removeComments": false,
     "esModuleInterop": true,


### PR DESCRIPTION
When importing Penumbra, imports TS natively, rather than a built version.