### PR TITLE
Fixes penumbra.save(), broken streamsaver import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.8.2",
+  "version": "4.9.0",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",


### PR DESCRIPTION
this is the key to why https://github.com/transcend-io/main/issues/3456 is failing

the inline imports were not type checking. just pulled them out to root and realized the module name changed.