### PR TITLE
Improve saveZip() usability with synthetic PenumbraFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,34 +60,6 @@ export type PenumbraDecryptionInfoAsBuffer = Omit<
   iv: Buffer;
 };
 
-/** Penumbra file composition */
-export type PenumbraFile = {
-  /** Backing stream */
-  stream: ReadableStream | ArrayBuffer;
-  /** File size (if backed by a ReadableStream) */
-  size?: number;
-  /** File mimetype */
-  mimetype: string;
-  /** Filename (excluding extension) */
-  filePrefix: string;
-  /** Relative file path (needed for zipping) */
-  path: string;
-  /** Optional ID for tracking encryption completion */
-  id?: number;
-};
-
-/** Penumbra file that is currently being encrypted */
-export type PenumbraFileWithID = PenumbraFile & {
-  /** ID for tracking encryption completion */
-  id: number;
-};
-
-/** penumbra file (internal) */
-export type PenumbraEncryptedFile = Omit<PenumbraFileWithID, 'stream'> & {
-  /** Encrypted output stream */
-  stream: ReadableStream | ArrayBuffer;
-};
-
 /**
  * A file to download from a remote resource, that is optionally encrypted
  */
@@ -104,6 +76,28 @@ export type RemoteResource = {
   path?: string;
   /** Fetch options */
   requestInit?: RequestInit;
+};
+
+/** Penumbra file composition */
+export type PenumbraFile = Omit<RemoteResource, 'url'> & {
+  /** Backing stream */
+  stream: ReadableStream | ArrayBuffer;
+  /** File size (if backed by a ReadableStream) */
+  size?: number;
+  /** Optional ID for tracking encryption completion */
+  id?: number | string;
+};
+
+/** Penumbra file that is currently being encrypted */
+export type PenumbraFileWithID = PenumbraFile & {
+  /** ID for tracking encryption completion */
+  id: number;
+};
+
+/** penumbra file (internal) */
+export type PenumbraEncryptedFile = Omit<PenumbraFileWithID, 'stream'> & {
+  /** Encrypted output stream */
+  stream: ReadableStream | ArrayBuffer;
 };
 
 /** Penumbra event types */

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ import penumbra from './API';
 import { PenumbraError } from './error';
 import { PenumbraZipWriter } from './zip';
 
+export { PenumbraZipWriter } from './zip';
+
 /**
  * Make selected object keys defined by K optional in type T
  */

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -117,11 +117,16 @@ export class PenumbraZipWriter {
    * @param files - Decrypted PenumbraFile[] to add to zip
    */
   write(...files: PenumbraFile[]): void {
-    files.forEach(({ path, filePrefix, stream, mimetype }) => {
-      const hasExtension = /[^/]*\.\w+$/.test(path);
-      const name = `${path || filePrefix}${
-        hasExtension ? '' : mime.extension(mimetype)
-      }`;
+    files.forEach(({ path, filePrefix, stream, mimetype }, i) => {
+      const name = path || filePrefix || '';
+      if (!name) {
+        console.warn(
+          "PenumbraZipWriter: Filename unable to be determined. Defaulting to 'download'",
+          files[i],
+        );
+      }
+      const hasExtension = /[^/]*\.\w+$/.test(name);
+      const fullName = `${name}${hasExtension ? '' : mime.extension(mimetype)}`;
       this.writer.write({
         name,
         lastModified: new Date(0),

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -118,17 +118,11 @@ export class PenumbraZipWriter {
    */
   write(...files: PenumbraFile[]): void {
     files.forEach(({ path, filePrefix, stream, mimetype }, i) => {
-      const name = path || filePrefix || '';
-      if (!name) {
-        console.warn(
-          "PenumbraZipWriter: Filename unable to be determined. Defaulting to 'download'",
-          files[i],
-        );
-      }
+      const name = path || filePrefix || 'download';
       const hasExtension = /[^/]*\.\w+$/.test(name);
-      const fullName = `${name}${hasExtension ? '' : mime.extension(mimetype)}`;
+      const fullPath = `${name}${hasExtension ? '' : mime.extension(mimetype)}`;
       this.writer.write({
-        name,
+        name: fullPath,
         lastModified: new Date(0),
         stream: () =>
           stream instanceof ReadableStream

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -117,7 +117,7 @@ export class PenumbraZipWriter {
    * @param files - Decrypted PenumbraFile[] to add to zip
    */
   write(...files: PenumbraFile[]): void {
-    files.forEach(({ path, filePrefix, stream, mimetype }, i) => {
+    files.forEach(({ path, filePrefix, stream, mimetype }) => {
       const name = path || filePrefix || 'download';
       const hasExtension = /[^/]*\.\w+$/.test(name);
       const fullPath = `${name}${hasExtension ? '' : mime.extension(mimetype)}`;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -117,8 +117,13 @@ export class PenumbraZipWriter {
    * @param files - Decrypted PenumbraFile[] to add to zip
    */
   write(...files: PenumbraFile[]): void {
-    files.forEach(({ path, filePrefix, stream, mimetype }) => {
-      const name = path || filePrefix || 'download';
+    files.forEach(({ path, filePrefix, stream, mimetype }, i) => {
+      const name = path || filePrefix;
+      if (!name) {
+        throw new Error(
+          'PenumbraZipWriter.write(): Unable to determine filename',
+        );
+      }
       const hasExtension = /[^/]*\.\w+$/.test(name);
       const fullPath = `${name}${hasExtension ? '' : mime.extension(mimetype)}`;
       this.writer.write({


### PR DESCRIPTION
This PR makes PenumbraFile.filePrefix or PenumbraFile.path optional if one of the two values is defined. This will make it much easier to use `saveZip()` with synthetic entries.