### PR TITLE
Add progress tracking & duplicate file auto-renaming to saveZip API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,7 @@ module.exports = {
         comments: 200,
       },
     ],
-    'max-lines': ['error', 250],
+    'max-lines': ['error', 350],
     // "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
     'no-bitwise': [
       'error',

--- a/README.md
+++ b/README.md
@@ -188,22 +188,47 @@ type ZipOptions = {
   files?: PenumbraFile[];
   /** Abort controller for cancelling zip generation and saving */
   controller?: AbortController;
+  /** Allow & auto-rename duplicate files sent to writer. Defaults to on */
+  allowDuplicates: boolean;
   /** Zip archive compression level */
   compressionLevel?: number;
-  /** Store a copy of the resultant zip file in-memory for debug & testing */
-  debug?: boolean;
+  /** Store a copy of the resultant zip file in-memory for inspection & testing */
+  saveBuffer?: boolean;
+  /**
+   * Auto-registered `'progress'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('progress', onProgress)`
+   */
+  onProgress?(event: CustomEvent<ZipProgressDetails>): void;
+  /**
+   * Auto-registered `'complete'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('complete', onComplete)`
+   */
+  onComplete?(event: CustomEvent<{}>): void;
 };
 
 penumbra.saveZip(options?: ZipOptions): PenumbraZipWriter;
 
-interface PenumbraZipWriter {
+interface PenumbraZipWriter extends EventTarget {
   /** Add decrypted PenumbraFiles to zip */
   write(...files: PenumbraFile[]): Promise<void>;
   /** Enqueue closing of the Penumbra zip writer (after pending writes finish) */
   close(): Promise<void>;
   /** Cancel Penumbra zip writer */
   abort(): void;
+  /** Get buffered output (requires saveBuffer mode) */
+  getBuffer(): Promise<ArrayBuffer>;
+  /** Get all written & pending file paths */
+  getFiles(): string[];
 }
+
+type ZipProgressDetails = {
+  /** Percentage completed */
+  percent: number;
+  /** Total bytes read */
+  totalBytesRead: number;
+  /** Total number of bytes to read */
+  contentLength: number;
+};
 ```
 
 Example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/API.ts
+++ b/src/API.ts
@@ -539,7 +539,7 @@ export async function decrypt(
 function getTextOrURI(files: PenumbraFile[]): Promise<PenumbraTextOrURI>[] {
   return files.map(
     async (file): Promise<PenumbraTextOrURI> => {
-      const { mimetype } = file;
+      const { mimetype = '' } = file;
       if (isViewableText(mimetype)) {
         return {
           type: 'text',

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -355,6 +355,7 @@ const onReady = async (
           );
           const expectedReferenceHashes = [
             '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
+            '2b8c82efb241668778c56a7bd9f8f6da389149ba7607f5249c88618bca70f017',
           ];
           let progressEventFiredAndWorking = false;
           let completeEventFired = false;

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -311,20 +311,19 @@ const onReady = async (
       },
     ],
     [
-      'penumbra.saveZip({ debug: true }) (zip hash checking)',
+      'penumbra.saveZip({ saveBuffer: true }) (zip hash checking)',
       async () =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise(async (resolve) => {
-          const files = [
+          const files = await penumbra.get(
             {
-              url:
-                'https://s3-us-west-2.amazonaws.com/bencmbrook/tortoise.jpg.enc',
-              path: 'test/tortoise.jpg',
-              mimetype: 'image/jpeg',
+              url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+              path: 'test/NYT.txt',
+              mimetype: 'text/plain',
               decryptionOptions: {
                 key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
                 iv: '6lNU+2vxJw6SFgse',
-                authTag: 'ELry8dZ3djg8BRB+7TyXZA==',
+                authTag: 'gadZhS1QozjEmfmHLblzbg==',
               },
               // for hash consistency
               lastModified: new Date(0),
@@ -341,15 +340,50 @@ const onReady = async (
               // for hash consistency
               lastModified: new Date(0),
             },
-          ];
+            {
+              url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+              path: 'test/NYT.txt',
+              mimetype: 'text/plain',
+              decryptionOptions: {
+                key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+                iv: '6lNU+2vxJw6SFgse',
+                authTag: 'gadZhS1QozjEmfmHLblzbg==',
+              },
+              // for hash consistency
+              lastModified: new Date(0),
+            },
+          );
           const expectedReferenceHashes = [
-            '390da5d34d30c66687b340443da75f06826141fd169bf9bc95b5ac8a5a23968f',
-            'e0df17053159a9e77a28d3deddbca7e4df7f42f0b5f66d58ce785341a18a7bab',
-            '1fb6d556738fae8138816a2e09bbfd026cd4abaabde2633634a1a699569bceeb',
+            '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
           ];
-          const writer = penumbra.saveZip({ debug: true });
-          await writer.write(...(await penumbra.get(...files)));
+          let progressEventFiredAndWorking = false;
+          let completeEventFired = false;
+          const expectedProgressProps = [
+            'percent',
+            'totalBytesRead',
+            'contentLength',
+          ];
+          const writer = penumbra.saveZip({
+            files,
+            /** onProgress handler */
+            onProgress(event) {
+              progressEventFiredAndWorking = expectedProgressProps.every(
+                (prop) => prop in event.detail,
+              );
+            },
+            /** onComplete handler */
+            onComplete() {
+              completeEventFired = true;
+            },
+            allowDuplicates: true,
+            saveBuffer: true,
+          });
           await writer.close();
+          console.log(
+            progressEventFiredAndWorking,
+            'zip progress event fired & emitted expected properties',
+          );
+          console.log(completeEventFired, 'zip complete event fired');
           const zipBuffer = await writer.getBuffer();
           const zipHash = await hash('SHA-256', zipBuffer);
           console.log('zip hash:', zipHash);

--- a/src/fetchAndDecrypt.ts
+++ b/src/fetchAndDecrypt.ts
@@ -3,9 +3,9 @@
 import { createDecipheriv } from 'crypto-browserify';
 
 // local
+import type { RemoteResource } from './types';
 import decryptStream from './decrypt';
 import { PenumbraError } from './error';
-import { RemoteResource } from './types';
 import { toBuff } from './utils';
 import emitError from './utils/emitError';
 

--- a/src/fetchAndDecrypt.ts
+++ b/src/fetchAndDecrypt.ts
@@ -3,7 +3,7 @@
 import { createDecipheriv } from 'crypto-browserify';
 
 // local
-import type { RemoteResource } from './types';
+import { RemoteResource } from './types';
 import decryptStream from './decrypt';
 import { PenumbraError } from './error';
 import { toBuff } from './utils';

--- a/src/getDecryptedContent.ts
+++ b/src/getDecryptedContent.ts
@@ -18,9 +18,10 @@ export default async function getDecryptedContent(
 ): Promise<string | Response> {
   // Fetch the resource
   const rs = await fetchAndDecrypt(resource);
+  const { mimetype = '' } = resource;
 
   // Return the decrypted content
-  const type = resource.mimetype
+  const type = mimetype
     .split('/')[0]
     .trim()
     .toLowerCase();
@@ -28,7 +29,7 @@ export default async function getDecryptedContent(
     if (MEDIA_TYPES.includes(type)) {
       return getMediaSrcFromRS(rs);
     }
-    if (type === 'text' || TEXT_TYPES.test(resource.mimetype)) {
+    if (type === 'text' || TEXT_TYPES.test(mimetype)) {
       return getTextFromRS(rs);
     }
   }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -3,7 +3,7 @@
 
 // local
 import { PenumbraAPI, PenumbraSupportLevel } from './types';
-import type { PenumbraZipWriter } from './zip';
+import { PenumbraZipWriter } from './zip';
 
 const supported = (): PenumbraSupportLevel => -0;
 supported.levels = PenumbraSupportLevel;

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -3,7 +3,7 @@
 
 // local
 import { PenumbraAPI, PenumbraSupportLevel } from './types';
-import { PenumbraZipWriter } from './zip';
+import type { PenumbraZipWriter } from './zip';
 
 const supported = (): PenumbraSupportLevel => -0;
 supported.levels = PenumbraSupportLevel;

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -1,20 +1,19 @@
 /* eslint-disable max-lines */
 import test from 'tape';
 import Bowser from 'bowser';
-import type {
+import {
   PenumbraAPI,
   PenumbraFile,
   PenumbraReady,
   ProgressEmit,
   ZipProgressEmit,
-  ZipCompletionEmit,
+  PenumbraSupportLevel,
 } from '../types';
-import { PenumbraSupportLevel } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // import penumbra from '../API';
 import { hash, timeout } from './helpers';
-import type { TimeoutManager } from './helpers/timeout';
+import { TimeoutManager } from './helpers/timeout';
 
 // This browser name, e.g. 'Chrome', 'Safari', 'Firefox', ...
 const browserName = Bowser.getParser(navigator.userAgent).getBrowserName();
@@ -352,7 +351,6 @@ test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)
   const expectedReferenceHashes = [
     '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
     '2b8c82efb241668778c56a7bd9f8f6da389149ba7607f5249c88618bca70f017',
-
   ];
   let progressEventFiredAndWorking = false;
   let completeEventFired = false;
@@ -361,17 +359,22 @@ test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)
     files,
     /** onProgress handler */
     onProgress(event: ZipProgressEmit) {
-      progressEventFiredAndWorking = expectedProgressProps.every((prop) => prop in event.detail);
+      progressEventFiredAndWorking = expectedProgressProps.every(
+        (prop) => prop in event.detail,
+      );
     },
     /** onComplete handler */
     onComplete() {
       completeEventFired = true;
     },
     allowDuplicates: true,
-    saveBuffer: true
+    saveBuffer: true,
   });
   await writer.close();
-  t.ok(progressEventFiredAndWorking, 'zip progress event fired & emitted expected properties');
+  t.ok(
+    progressEventFiredAndWorking,
+    'zip progress event fired & emitted expected properties',
+  );
   t.ok(completeEventFired, 'zip complete event fired');
   t.pass('zip saved');
   const zipBuffer = await writer.getBuffer();

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -1,18 +1,20 @@
 /* eslint-disable max-lines */
 import test from 'tape';
 import Bowser from 'bowser';
-import {
+import type {
   PenumbraAPI,
   PenumbraFile,
   PenumbraReady,
   ProgressEmit,
-  PenumbraSupportLevel,
+  ZipProgressEmit,
+  ZipCompletionEmit,
 } from '../types';
+import { PenumbraSupportLevel } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // import penumbra from '../API';
 import { hash, timeout } from './helpers';
-import { TimeoutManager } from './helpers/timeout';
+import type { TimeoutManager } from './helpers/timeout';
 
 // This browser name, e.g. 'Chrome', 'Safari', 'Firefox', ...
 const browserName = Bowser.getParser(navigator.userAgent).getBrowserName();
@@ -300,23 +302,24 @@ test('penumbra.encrypt() & penumbra.decrypt()', async (t) => {
   t.end();
 });
 
-test('penumbra.saveZip({ debug: true }) (zip hash checking)', async (t) => {
+test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)', async (t) => {
   if (['Firefox', 'Safari'].includes(browserName)) {
     t.pass(
-      `penumbra.saveZip({ debug: true }) test skipped for ${browserName}. TODO: Fix penumbra.encrypt() in ${browserName}!`,
+      // eslint-disable-next-line max-len
+      `penumbra.saveZip({ saveBuffer: true }) test skipped for ${browserName}. TODO: Fix penumbra.encrypt() in ${browserName}!`,
     );
     t.end();
     return;
   }
-  const files = [
+  const files = await penumbra.get(
     {
-      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/tortoise.jpg.enc',
-      path: 'test/tortoise.jpg',
-      mimetype: 'image/jpeg',
+      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+      path: 'test/NYT.txt',
+      mimetype: 'text/plain',
       decryptionOptions: {
         key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
         iv: '6lNU+2vxJw6SFgse',
-        authTag: 'ELry8dZ3djg8BRB+7TyXZA==',
+        authTag: 'gadZhS1QozjEmfmHLblzbg==',
       },
       // for hash consistency
       lastModified: new Date(0),
@@ -333,15 +336,41 @@ test('penumbra.saveZip({ debug: true }) (zip hash checking)', async (t) => {
       // for hash consistency
       lastModified: new Date(0),
     },
-  ];
+    {
+      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+      path: 'test/NYT.txt',
+      mimetype: 'text/plain',
+      decryptionOptions: {
+        key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+        iv: '6lNU+2vxJw6SFgse',
+        authTag: 'gadZhS1QozjEmfmHLblzbg==',
+      },
+      // for hash consistency
+      lastModified: new Date(0),
+    },
+  );
   const expectedReferenceHashes = [
-    '390da5d34d30c66687b340443da75f06826141fd169bf9bc95b5ac8a5a23968f',
-    'e0df17053159a9e77a28d3deddbca7e4df7f42f0b5f66d58ce785341a18a7bab',
-    '1fb6d556738fae8138816a2e09bbfd026cd4abaabde2633634a1a699569bceeb',
+    '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
   ];
-  const writer = penumbra.saveZip({ debug: true });
-  await writer.write(...(await penumbra.get(...files)));
+  let progressEventFiredAndWorking = false;
+  let completeEventFired = false;
+  const expectedProgressProps = ['percent', 'totalBytesRead', 'contentLength'];
+  const writer = penumbra.saveZip({
+    files,
+    /** onProgress handler */
+    onProgress(event: ZipProgressEmit) {
+      progressEventFiredAndWorking = expectedProgressProps.every((prop) => prop in event.detail);
+    },
+    /** onComplete handler */
+    onComplete() {
+      completeEventFired = true;
+    },
+    allowDuplicates: true,
+    saveBuffer: true
+  });
   await writer.close();
+  t.ok(progressEventFiredAndWorking, 'zip progress event fired & emitted expected properties');
+  t.ok(completeEventFired, 'zip complete event fired');
   t.pass('zip saved');
   const zipBuffer = await writer.getBuffer();
   const zipHash = await hash('SHA-256', zipBuffer);

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -351,6 +351,8 @@ test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)
   );
   const expectedReferenceHashes = [
     '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
+    '2b8c82efb241668778c56a7bd9f8f6da389149ba7607f5249c88618bca70f017',
+
   ];
   let progressEventFiredAndWorking = false;
   let completeEventFired = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,11 @@
  */
 
 // local
-import type penumbra from './API';
-import type { PenumbraError } from './error';
-import type { PenumbraZipWriter } from './zip';
+import penumbra from './API';
+import { PenumbraError } from './error';
+import { PenumbraZipWriter } from './zip';
 
-export type { PenumbraZipWriter } from './zip';
+export { PenumbraZipWriter } from './zip';
 
 /**
  * Make selected object keys defined by K optional in type T

--- a/src/types.ts
+++ b/src/types.ts
@@ -365,3 +365,31 @@ export type EventForwarder = {
   /** Comlink-proxied main thread progress event transfer handler */
   handler?: (event: Event) => void;
 };
+
+/** PenumbraZipWriter constructor options */
+export type ZipOptions = Partial<{
+  /** Filename to save to (.zip is optional) */
+  name?: string;
+  /** Total size of archive (if known ahead of time, for 'store' compression level) */
+  size?: number;
+  /** Files (in-memory & remote) to add to zip archive */
+  files: PenumbraFile[];
+  /** Abort controller for cancelling zip generation and saving */
+  controller: AbortController;
+  /** Allow & auto-rename duplicate files sent to writer. Defaults to on */
+  allowDuplicates: boolean;
+  /** Zip archive compression level */
+  compressionLevel: number;
+  /** Store a copy of the resultant zip file in-memory for inspection & testing */
+  saveBuffer: boolean;
+  /**
+   * Auto-registered `'progress'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('progress', onProgress)`
+   */
+  onProgress?(event: ZipProgressEmit): void;
+  /**
+   * Auto-registered `'write-complete'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('complete', onComplete)`
+   */
+  onComplete?(event: ZipCompletionEmit): void;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type RemoteResource = {
   /** The URL to fetch the encrypted or unencrypted file from */
   url: string;
   /** The mimetype of the resulting file */
-  mimetype: string;
+  mimetype?: string;
   /** The name of the underlying file without the extension */
   filePrefix?: string;
   /** If the file is encrypted, these are the required params */
@@ -205,7 +205,7 @@ export type PenumbraTextOrURI = {
   /** Data */
   data: string;
   /** MIME type */
-  mimetype: string;
+  mimetype?: string;
 };
 
 /** Penumbra API */

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,11 @@
  */
 
 // local
-import penumbra from './API';
-import { PenumbraError } from './error';
-import { PenumbraZipWriter } from './zip';
+import type penumbra from './API';
+import type { PenumbraError } from './error';
+import type { PenumbraZipWriter } from './zip';
 
-export { PenumbraZipWriter } from './zip';
+export type { PenumbraZipWriter } from './zip';
 
 /**
  * Make selected object keys defined by K optional in type T
@@ -78,6 +78,8 @@ export type RemoteResource = {
   path?: string;
   /** Fetch options */
   requestInit?: RequestInit;
+  /** Last modified date */
+  lastModified?: Date;
 };
 
 /** Penumbra file composition */
@@ -126,9 +128,41 @@ export type ProgressDetails = {
 };
 
 /**
- * The type that is emitted as progress continues
+ * The type that is emitted as progress continuesZipWrite
  */
 export type ProgressEmit = CustomEvent<ProgressDetails>;
+
+/**
+ * Zip progress event details
+ */
+export type ZipProgressDetails = {
+  /** The ID of the worker thread that is processing this job */
+  worker?: number | null;
+  /** Percentage completed */
+  percent: number;
+  /** Total bytes read */
+  totalBytesRead: number;
+  /** Total number of bytes to read */
+  contentLength: number;
+};
+
+/**
+ * The type that is emitted as zip writes progresses
+ */
+export type ZipProgressEmit = CustomEvent<ZipProgressDetails>;
+
+/**
+ * Zip completion event details
+ */
+export type ZipCompletionDetails = {
+  /** The ID of the worker thread that is processing this job */
+  worker?: number | null;
+};
+
+/**
+ * The type that is emitted as progress continues
+ */
+export type ZipCompletionEmit = CustomEvent<ZipCompletionDetails>;
 
 /**
  * Penumbra error event details

--- a/src/utils/emitJobCompletion.ts
+++ b/src/utils/emitJobCompletion.ts
@@ -1,6 +1,6 @@
 // penumbra
 import { PenumbraEvent } from '../event';
-import type { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
+import { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
 
 /**
  * An event emitter for job completion
@@ -10,7 +10,7 @@ import type { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
 export default function emitJobCompletion(
   id: number,
   decryptionInfo: PenumbraDecryptionInfo,
-  target: EventTarget = self
+  target: EventTarget = self,
 ): void {
   const emitContent: Pick<JobCompletionEmit, 'detail'> = {
     detail: { id, decryptionInfo },

--- a/src/utils/emitJobCompletion.ts
+++ b/src/utils/emitJobCompletion.ts
@@ -1,6 +1,6 @@
 // penumbra
 import { PenumbraEvent } from '../event';
-import { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
+import type { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
 
 /**
  * An event emitter for job completion
@@ -10,6 +10,7 @@ import { JobCompletionEmit, PenumbraDecryptionInfo } from '../types';
 export default function emitJobCompletion(
   id: number,
   decryptionInfo: PenumbraDecryptionInfo,
+  target: EventTarget = self
 ): void {
   const emitContent: Pick<JobCompletionEmit, 'detail'> = {
     detail: { id, decryptionInfo },
@@ -17,5 +18,5 @@ export default function emitJobCompletion(
 
   // Dispatch the event
   const event = new PenumbraEvent('penumbra-complete', emitContent);
-  self.dispatchEvent(event);
+  target.dispatchEvent(event);
 }

--- a/src/utils/emitProgress.ts
+++ b/src/utils/emitProgress.ts
@@ -1,5 +1,5 @@
 // penumbra
-import type { PenumbraEventType, ProgressEmit } from '../types';
+import { PenumbraEventType, ProgressEmit } from '../types';
 import { PenumbraEvent } from '../event';
 
 /**

--- a/src/utils/emitProgress.ts
+++ b/src/utils/emitProgress.ts
@@ -1,5 +1,5 @@
 // penumbra
-import { PenumbraEventType, ProgressEmit } from '../types';
+import type { PenumbraEventType, ProgressEmit } from '../types';
 import { PenumbraEvent } from '../event';
 
 /**
@@ -14,6 +14,7 @@ export default function emitProgress(
   totalBytesRead: number,
   contentLength: number,
   id: string | number,
+  target: EventTarget = self,
 ): void {
   // Calculate the progress remaining
   const percent = Math.round((totalBytesRead / contentLength) * 100);
@@ -30,5 +31,5 @@ export default function emitProgress(
 
   // Dispatch the event
   const event = new PenumbraEvent('penumbra-progress', emitContent);
-  self.dispatchEvent(event);
+  target.dispatchEvent(event);
 }

--- a/src/utils/emitZipCompletion.ts
+++ b/src/utils/emitZipCompletion.ts
@@ -1,5 +1,5 @@
 // penumbra
-import type { PenumbraZipWriter, ZipCompletionEmit } from '../types';
+import { PenumbraZipWriter, ZipCompletionEmit } from '../types';
 import { PenumbraEvent } from '../event';
 
 /**
@@ -8,7 +8,7 @@ import { PenumbraEvent } from '../event';
  */
 export default function emitZipCompletion(writer: PenumbraZipWriter): void {
   const emitContent: Pick<ZipCompletionEmit, 'detail'> = {
-    detail: { },
+    detail: {},
   };
 
   // Dispatch the event

--- a/src/utils/emitZipCompletion.ts
+++ b/src/utils/emitZipCompletion.ts
@@ -1,0 +1,17 @@
+// penumbra
+import type { PenumbraZipWriter, ZipCompletionEmit } from '../types';
+import { PenumbraEvent } from '../event';
+
+/**
+ * An event emitter for zip writer file completion
+ * @param writer - PenumbraZipWriter instance
+ */
+export default function emitZipCompletion(writer: PenumbraZipWriter): void {
+  const emitContent: Pick<ZipCompletionEmit, 'detail'> = {
+    detail: { },
+  };
+
+  // Dispatch the event
+  const event = new PenumbraEvent('complete', emitContent);
+  writer.dispatchEvent(event);
+}

--- a/src/utils/emitZipProgress.ts
+++ b/src/utils/emitZipProgress.ts
@@ -1,0 +1,31 @@
+// penumbra
+import type { PenumbraZipWriter, ZipProgressEmit } from '../types';
+import { PenumbraEvent } from '../event';
+
+/**
+ * An event emitter for PenumbraZipWriter progress
+ * @param writer - PenumbraZipWriter instance
+ * @param totalBytesRead - The number of bytes or items written so far
+ * @param contentLength - The total number of bytes or items to write
+ * @returns
+ */
+export default function emitZipProgress(
+  writer: PenumbraZipWriter,
+  totalBytesRead: number,
+  contentLength: number,
+): void {
+  // Calculate the progress remaining
+  const percent = Math.round((totalBytesRead / contentLength) * 100);
+
+  const emitContent: Pick<ZipProgressEmit, 'detail'> = {
+    detail: {
+      percent,
+      totalBytesRead,
+      contentLength,
+    },
+  };
+
+  // Dispatch the event
+  const event = new PenumbraEvent('progress', emitContent);
+  writer.dispatchEvent(event);
+}

--- a/src/utils/emitZipProgress.ts
+++ b/src/utils/emitZipProgress.ts
@@ -1,5 +1,5 @@
 // penumbra
-import type { PenumbraZipWriter, ZipProgressEmit } from '../types';
+import { PenumbraZipWriter, ZipProgressEmit } from '../types';
 import { PenumbraEvent } from '../event';
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,9 @@ import 'regenerator-runtime/runtime';
 
 // local
 export { default as emitProgress } from './emitProgress';
+export { default as emitJobCompletion } from './emitJobCompletion';
+export { default as emitZipProgress } from './emitZipProgress';
+export { default as emitZipCompletion } from './emitZipCompletion';
 export { default as getKeys } from './getKeys';
 export { default as getOrigins } from './getOrigins';
 export { default as getMediaSrcFromRS } from './getMediaSrcFromRS';

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -2,22 +2,36 @@ import allSettled from 'promise.allsettled';
 import { Writer } from '@transcend-io/conflux';
 import { createWriteStream } from 'streamsaver';
 import mime from 'mime-types';
-import { PenumbraFile } from './types';
+import type { PenumbraFile, ZipProgressEmit, ZipCompletionEmit, RemoteResource } from './types';
+import emitZipProgress from './utils/emitZipProgress';
+import emitZipCompletion from './utils/emitZipCompletion';
 
 /** PenumbraZipWriter constructor options */
 export type ZipOptions = Partial<{
   /** Filename to save to (.zip is optional) */
-  name: string;
+  name?: string;
   /** Total size of archive (if known ahead of time, for 'store' compression level) */
-  size: number;
-  /** PenumbraFile[] to add to zip archive */
+  size?: number;
+  /** Files (in-memory & remote) to add to zip archive */
   files: PenumbraFile[];
   /** Abort controller for cancelling zip generation and saving */
   controller: AbortController;
+  /** Allow & auto-rename duplicate files sent to writer. Defaults to on */
+  allowDuplicates: boolean;
   /** Zip archive compression level */
   compressionLevel: number;
-  /** Store a copy of the resultant zip file in-memory for debug & testing */
-  debug: boolean;
+  /** Store a copy of the resultant zip file in-memory for inspection & testing */
+  saveBuffer: boolean;
+  /**
+   * Auto-registered `'progress'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('progress', onProgress)`
+   */
+  onProgress?(event: ZipProgressEmit): void;
+  /**
+   * Auto-registered `'write-complete'` event listener. This is equivalent to calling
+   * `PenumbraZipWriter.addEventListener('complete', onComplete)`
+   */
+  onComplete?(event: ZipCompletionEmit): void;
 }>;
 
 /** Compression levels */
@@ -33,7 +47,7 @@ export enum Compression {
 }
 
 /** Wrapped WritableStream for state keeping with StreamSaver */
-export class PenumbraZipWriter {
+export class PenumbraZipWriter extends EventTarget {
   /** Conflux zip writer instance */
   private conflux: Writer = new Writer();
 
@@ -43,17 +57,32 @@ export class PenumbraZipWriter {
   /** Save completion state */
   private closed = false;
 
-  /** Debug mode */
-  private debug = false;
+  /** Save complete buffer */
+  private saveBuffer = false;
 
-  /** Debug zip buffer used for testing */
-  private debugZipBuffer: Promise<ArrayBuffer> | undefined;
+  /** Zip buffer used for testing */
+  private zipBuffer: Promise<ArrayBuffer> | undefined;
 
-  /** Pending unfinished write() calls */
-  private pendingWrites: Promise<void>[] = [];
+  /** Allow & auto-rename duplicate files sent to writer */
+  private allowDuplicates: boolean;
+
+  /** All written & pending file paths */
+  private files = new Set<string>();
 
   /** Abort controller */
   private controller: AbortController;
+
+  /** All pending finished and unfinished zip file writes */
+  private writes: Promise<void>[] = [];
+
+  /** Number of finished zip file writes */
+  private completedWrites = 0;
+
+  /** Total zip archive size */
+  private byteSize: number | null = 0;
+
+  /** Current zip archive size */
+  private bytesWritten = 0;
 
   /**
    * Penumbra zip writer constructor
@@ -62,22 +91,28 @@ export class PenumbraZipWriter {
    * @returns PenumbraZipWriter class instance
    */
   constructor(options: ZipOptions = {}) {
+    super();
+
     const {
       name = 'download',
       size,
       files,
       controller = new AbortController(),
       compressionLevel = Compression.Store,
-      debug = false,
+      saveBuffer = false,
+      allowDuplicates = true,
+      onProgress,
+      onComplete
     } = options;
 
     if (compressionLevel !== Compression.Store) {
       throw new Error(
         // eslint-disable-next-line max-len
-        "penumbra.saveZip() doesn't support compression yet. Voice your support here: https://github.com/transcend-io/penumbra/issues",
+        "penumbra.saveZip() does not support compression yet. Voice your support here: https://github.com/transcend-io/penumbra/issues",
       );
     }
 
+    this.allowDuplicates = allowDuplicates;
     this.controller = controller;
     const { signal } = controller;
     signal.addEventListener(
@@ -90,6 +125,17 @@ export class PenumbraZipWriter {
       },
     );
 
+    // Auto-register onProgress & onComplete listeners
+    if (typeof onProgress === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.addEventListener('progress', onProgress as any);
+    }
+
+    if (typeof onComplete === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.addEventListener('complete', onComplete as any);
+    }
+
     const saveStream = createWriteStream(
       // Append .zip to filename unless it is already present
       /\.zip\s*$/i.test(name) ? name : `${name}.zip`,
@@ -97,17 +143,17 @@ export class PenumbraZipWriter {
     );
 
     const { readable } = this.conflux;
-    const [zipStream, debugZipStream]: [
+    const [zipStream, bufferedZipStream]: [
       ReadableStream,
       ReadableStream | null,
-    ] = debug ? readable.tee() : [readable, null];
+    ] = saveBuffer ? readable.tee() : [readable, null];
 
     zipStream.pipeTo(saveStream, { signal });
 
     // Buffer zip stream for debug & testing
-    if (debug && debugZipStream) {
-      this.debug = debug;
-      this.debugZipBuffer = new Response(debugZipStream).arrayBuffer();
+    if (saveBuffer && bufferedZipStream) {
+      this.saveBuffer = saveBuffer;
+      this.zipBuffer = new Response(bufferedZipStream).arrayBuffer();
     }
 
     if (files) {
@@ -121,6 +167,18 @@ export class PenumbraZipWriter {
    * @param files - Decrypted PenumbraFile[] to add to zip
    */
   write(...files: PenumbraFile[]): Promise<PromiseSettledResult<void>[]> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const zip = this;
+    // Add file sizes to total zip size
+    if (zip.byteSize !== null) {
+      const sizes = files.map(({size}) => size);
+      const sizeUnknown = sizes.some((size) => isNaN(size as number));
+      if (sizeUnknown) {
+        zip.byteSize = null;
+      } else {
+        zip.byteSize += files.map(({ size }) => size || 0).reduce((acc, val) => acc + val);
+      }
+    }
     return allSettled(
       files.map(
         async ({
@@ -130,16 +188,41 @@ export class PenumbraZipWriter {
           mimetype,
           lastModified = new Date(),
         }) => {
+          // Resolve file path
           const name = path || filePrefix;
           if (!name) {
             throw new Error(
               'PenumbraZipWriter.write(): Unable to determine filename',
             );
           }
-          const hasExtension = /[^/]*\.\w+$/.test(name);
-          const fullPath = `${name}${
-            hasExtension ? '' : mime.extension(mimetype)
-          }`;
+          const [filename, extension = mime.extension(mimetype)] = name
+            .split(/(\.\w+\s*$)/) // split filename extension
+            .filter(Boolean); // filter empty matches
+          let filePath = `${filename}${extension}`;
+
+          // Handle duplicate files
+          if (zip.files.has(filePath)) {
+            const warning = `penumbra.saveZip(): Duplicate file detected: ${filePath}`;
+            if (zip.allowDuplicates) {
+              console.warn(warning);
+            } else {
+              this.abort();
+              throw new Error(warning);
+            }
+
+            // This code picks a filename when auto-renaming conflicting files.
+            // If {filename}{extension} exists it will create {filename} (1){extension}, etc.
+            let i = 0;
+            // eslint-disable-next-line no-plusplus
+            while (zip.files.has(`${filename} (${++i})${extension}`));
+            filePath = `${filename} (${i})${extension}`;
+            console.warn(
+              `penumbra.saveZip(): Duplicate file renamed: ${filePath}`,
+            );
+          }
+
+          zip.files.add(filePath);
+
           const reader = (stream instanceof ReadableStream
             ? stream
             : (new Response(stream).body as ReadableStream)
@@ -152,10 +235,22 @@ export class PenumbraZipWriter {
                 while (true) {
                   // eslint-disable-next-line no-await-in-loop
                   const { done, value } = await reader.read();
-
+                  if (zip.byteSize !== null) {
+                    zip.bytesWritten += value.byteLength;
+                    emitZipProgress(zip, zip.bytesWritten, zip.byteSize);
+                  }
                   // When no more data needs to be consumed, break the reading
                   if (done) {
                     resolve();
+                    // eslint-disable-next-line no-plusplus
+                    zip.completedWrites++;
+                    // Emit file-granular progress events when total byte size can't be determined
+                    if (zip.byteSize === null) {
+                      emitZipProgress(zip, zip.completedWrites, zip.writes.length);
+                    }
+                    if (zip.completedWrites >= zip.writes.length) {
+                      emitZipCompletion(zip);
+                    }
                     break;
                   }
 
@@ -169,14 +264,14 @@ export class PenumbraZipWriter {
               },
             });
 
-            this.writer.write({
-              name: fullPath,
+            zip.writer.write({
+              name: filePath,
               lastModified,
               stream: () => completionTrackerStream,
             });
           });
 
-          this.pendingWrites.push(writeComplete);
+          zip.writes.push(writeComplete);
           return writeComplete;
         },
       ),
@@ -185,7 +280,7 @@ export class PenumbraZipWriter {
 
   /** Enqueue closing of the Penumbra zip writer (after pending writes finish) */
   async close(): Promise<PromiseSettledResult<void>[]> {
-    const writes = await allSettled(this.pendingWrites);
+    const writes = await allSettled(this.writes);
     if (!this.closed) {
       this.writer.close();
       this.closed = true;
@@ -200,19 +295,24 @@ export class PenumbraZipWriter {
     }
   }
 
-  /** Get buffered output (requires debug mode) */
+  /** Get buffered output (requires saveBuffer mode) */
   getBuffer(): Promise<ArrayBuffer> {
     if (!this.closed) {
       throw new Error(
         'getBuffer() can only be called when a PenumbraZipWriter is closed',
       );
     }
-    if (!this.debug || !this.debugZipBuffer) {
+    if (!this.saveBuffer || !this.zipBuffer) {
       throw new Error(
-        'getBuffer() can only be called on a PenumbraZipWriter in debug mode',
+        'getBuffer() can only be called on a PenumbraZipWriter in buffered mode, e.g. createZip({ saveBuffer: true })',
       );
     }
-    return this.debugZipBuffer;
+    return this.zipBuffer;
+  }
+
+  /** Get all written & pending file paths */
+  getFiles(): string[] {
+    return [...this.files];
   }
 }
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -148,8 +148,8 @@ export class PenumbraZipWriter extends EventTarget {
       if (sizeUnknown) {
         zip.byteSize = null;
       } else {
-        zip.byteSize += files
-          .map(({ size }) => size || 0)
+        zip.byteSize += (files as { size: number }[])
+          .map(({ size }) => size)
           .reduce((acc, val) => acc + val);
       }
     }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -169,7 +169,10 @@ export class PenumbraZipWriter extends EventTarget {
               'PenumbraZipWriter.write(): Unable to determine filename',
             );
           }
-          const [filename, extension = mime.extension(mimetype)] = name
+          const [
+            filename,
+            extension = mimetype ? mime.extension(mimetype) : '',
+          ] = name
             .split(/(\.\w+\s*$)/) // split filename extension
             .filter(Boolean); // filter empty matches
           let filePath = `${filename}${extension}`;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -180,7 +180,7 @@ export class PenumbraZipWriter extends EventTarget {
             if (zip.allowDuplicates) {
               console.warn(warning);
             } else {
-              this.abort();
+              zip.abort();
               throw new Error(warning);
             }
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -2,7 +2,7 @@ import allSettled from 'promise.allsettled';
 import { Writer } from '@transcend-io/conflux';
 import { createWriteStream } from 'streamsaver';
 import mime from 'mime-types';
-import type { PenumbraFile, ZipOptions } from './types';
+import { PenumbraFile, ZipOptions } from './types';
 import emitZipProgress from './utils/emitZipProgress';
 import emitZipCompletion from './utils/emitZipCompletion';
 
@@ -74,13 +74,13 @@ export class PenumbraZipWriter extends EventTarget {
       saveBuffer = false,
       allowDuplicates = true,
       onProgress,
-      onComplete
+      onComplete,
     } = options;
 
     if (compressionLevel !== Compression.Store) {
       throw new Error(
         // eslint-disable-next-line max-len
-        "penumbra.saveZip() does not support compression yet. Voice your support here: https://github.com/transcend-io/penumbra/issues",
+        'penumbra.saveZip() does not support compression yet. Voice your support here: https://github.com/transcend-io/penumbra/issues',
       );
     }
 
@@ -143,12 +143,14 @@ export class PenumbraZipWriter extends EventTarget {
     const zip = this;
     // Add file sizes to total zip size
     if (zip.byteSize !== null) {
-      const sizes = files.map(({size}) => size);
+      const sizes = files.map(({ size }) => size);
       const sizeUnknown = sizes.some((size) => isNaN(size as number));
       if (sizeUnknown) {
         zip.byteSize = null;
       } else {
-        zip.byteSize += files.map(({ size }) => size || 0).reduce((acc, val) => acc + val);
+        zip.byteSize += files
+          .map(({ size }) => size || 0)
+          .reduce((acc, val) => acc + val);
       }
     }
     return allSettled(
@@ -218,7 +220,11 @@ export class PenumbraZipWriter extends EventTarget {
                     zip.completedWrites++;
                     // Emit file-granular progress events when total byte size can't be determined
                     if (zip.byteSize === null) {
-                      emitZipProgress(zip, zip.completedWrites, zip.writes.length);
+                      emitZipProgress(
+                        zip,
+                        zip.completedWrites,
+                        zip.writes.length,
+                      );
                     }
                     if (zip.completedWrites >= zip.writes.length) {
                       emitZipCompletion(zip);

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -2,37 +2,9 @@ import allSettled from 'promise.allsettled';
 import { Writer } from '@transcend-io/conflux';
 import { createWriteStream } from 'streamsaver';
 import mime from 'mime-types';
-import type { PenumbraFile, ZipProgressEmit, ZipCompletionEmit, RemoteResource } from './types';
+import type { PenumbraFile, ZipOptions } from './types';
 import emitZipProgress from './utils/emitZipProgress';
 import emitZipCompletion from './utils/emitZipCompletion';
-
-/** PenumbraZipWriter constructor options */
-export type ZipOptions = Partial<{
-  /** Filename to save to (.zip is optional) */
-  name?: string;
-  /** Total size of archive (if known ahead of time, for 'store' compression level) */
-  size?: number;
-  /** Files (in-memory & remote) to add to zip archive */
-  files: PenumbraFile[];
-  /** Abort controller for cancelling zip generation and saving */
-  controller: AbortController;
-  /** Allow & auto-rename duplicate files sent to writer. Defaults to on */
-  allowDuplicates: boolean;
-  /** Zip archive compression level */
-  compressionLevel: number;
-  /** Store a copy of the resultant zip file in-memory for inspection & testing */
-  saveBuffer: boolean;
-  /**
-   * Auto-registered `'progress'` event listener. This is equivalent to calling
-   * `PenumbraZipWriter.addEventListener('progress', onProgress)`
-   */
-  onProgress?(event: ZipProgressEmit): void;
-  /**
-   * Auto-registered `'write-complete'` event listener. This is equivalent to calling
-   * `PenumbraZipWriter.addEventListener('complete', onComplete)`
-   */
-  onComplete?(event: ZipCompletionEmit): void;
-}>;
 
 /** Compression levels */
 export enum Compression {


### PR DESCRIPTION
This PR adds byte-level progress tracking & duplicate file auto-renaming to saveZip API. The docs have been updated accordingly to reflect the new API changes.

### Progress tracking

You can either use `ZipOptions.onProgress = ({ detail: { percent } }) => { ... }` or call `penumbra.saveZip(...).addEventListener('progress', onProgress)` to register a progress event listener.

### File auto-renaming

Files with conflicting names are now allowed and auto-renamed by default (e.g. a duplicate `foo/bar.txt` would become `foo/bar (1).txt`, `foo/bar (2).txt`, etc.). You can disallow duplicate files & opt-out of auto-renaming by specifying `ZipOptions.allowDuplicates = false`.

### TODO

- [x] Implement byte-level progress & completion tracking
  - [x] Fallback to file-level progress & completion tracking
  - [x] Add tests
- [x] Zip content filename conflict resolution with auto-renaming
  - [x] Add tests
- [x] Small saveZip API usability tweaks (e.g. `ZipOptions.debug` was renamed to `ZipOptions.saveBuffer`)