### PR TITLE
Fix ZipOptions.size handling in penumbra.saveZip()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -51,7 +51,7 @@ export class PenumbraZipWriter extends EventTarget {
   private completedWrites = 0;
 
   /** Total zip archive size */
-  private byteSize: number | null = 0;
+  private byteSize: number | null;
 
   /** Current zip archive size */
   private bytesWritten = 0;
@@ -67,7 +67,7 @@ export class PenumbraZipWriter extends EventTarget {
 
     const {
       name = 'download',
-      size,
+      size = 0,
       files,
       controller = new AbortController(),
       compressionLevel = Compression.Store,
@@ -84,6 +84,7 @@ export class PenumbraZipWriter extends EventTarget {
       );
     }
 
+    this.byteSize = size;
     this.allowDuplicates = allowDuplicates;
     this.controller = controller;
     const { signal } = controller;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -84,8 +84,8 @@ export class PenumbraZipWriter extends EventTarget {
       );
     }
 
-    if (!isNaN(size as number)) {
-      this.byteSize = size as number;
+    if (size !== undefined && size !== null) {
+      this.byteSize = size;
     }
     this.allowDuplicates = allowDuplicates;
     this.controller = controller;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -84,8 +84,8 @@ export class PenumbraZipWriter extends EventTarget {
       );
     }
 
-    if (size !== undefined) {
-      this.byteSize = size;
+    if (!isNaN(size as number)) {
+      this.byteSize = size as number;
     }
     this.allowDuplicates = allowDuplicates;
     this.controller = controller;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -51,7 +51,7 @@ export class PenumbraZipWriter extends EventTarget {
   private completedWrites = 0;
 
   /** Total zip archive size */
-  private byteSize: number | null;
+  private byteSize: number | null = 0;
 
   /** Current zip archive size */
   private bytesWritten = 0;
@@ -67,7 +67,7 @@ export class PenumbraZipWriter extends EventTarget {
 
     const {
       name = 'download',
-      size = 0,
+      size,
       files,
       controller = new AbortController(),
       compressionLevel = Compression.Store,
@@ -84,7 +84,9 @@ export class PenumbraZipWriter extends EventTarget {
       );
     }
 
-    this.byteSize = size;
+    if (size !== undefined) {
+      this.byteSize = size;
+    }
     this.allowDuplicates = allowDuplicates;
     this.controller = controller;
     const { signal } = controller;


### PR DESCRIPTION
This PR should result in consistent over-all progress percentages when asynchronously paginating over large datasets.