### PR TITLE
PenumbraZipWriter dynamic size tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Save a zip containing files retrieved by Penumbra.
 type ZipOptions = {
   /** Filename to save to (.zip is optional) */
   name?: string;
-  /** Total size of archive (if known ahead of time, for 'store' compression level) */
+  /** Total size of archive in bytes (if known ahead of time, for 'store' compression level) */
   size?: number;
   /** PenumbraFile[] to add to zip archive */
   files?: PenumbraFile[];
@@ -204,15 +204,28 @@ type ZipOptions = {
    * `PenumbraZipWriter.addEventListener('complete', onComplete)`
    */
   onComplete?(event: CustomEvent<{}>): void;
+  /**
+   * Get observed zip size after all pending writes are resolved
+   */
+  getSize(): Promise<number>;
 };
 
 penumbra.saveZip(options?: ZipOptions): PenumbraZipWriter;
 
 interface PenumbraZipWriter extends EventTarget {
-  /** Add decrypted PenumbraFiles to zip */
-  write(...files: PenumbraFile[]): Promise<void>;
-  /** Enqueue closing of the Penumbra zip writer (after pending writes finish) */
-  close(): Promise<void>;
+  /**
+   * Add decrypted PenumbraFiles to zip
+   *
+   * @param files - Decrypted PenumbraFile[] to add to zip
+   * @returns Total observed size of write call in bytes
+   */
+  write(...files: PenumbraFile[]): Promise<number>;
+  /**
+   * Enqueue closing of the Penumbra zip writer (after pending writes finish)
+   *
+   * @returns Total observed zip size in bytes after close completes
+   */
+  close(): Promise<number>;
   /** Cancel Penumbra zip writer */
   abort(): void;
   /** Get buffered output (requires saveBuffer mode) */

--- a/README.md
+++ b/README.md
@@ -204,10 +204,6 @@ type ZipOptions = {
    * `PenumbraZipWriter.addEventListener('complete', onComplete)`
    */
   onComplete?(event: CustomEvent<{}>): void;
-  /**
-   * Get observed zip size after all pending writes are resolved
-   */
-  getSize(): Promise<number>;
 };
 
 penumbra.saveZip(options?: ZipOptions): PenumbraZipWriter;
@@ -232,6 +228,10 @@ interface PenumbraZipWriter extends EventTarget {
   getBuffer(): Promise<ArrayBuffer>;
   /** Get all written & pending file paths */
   getFiles(): string[];
+  /**
+   * Get observed zip size after all pending writes are resolved
+   */
+  getSize(): Promise<number>;
 }
 
 type ZipProgressDetails = {

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,11 +11,6 @@ module.exports = {
           chrome: '85',
           safari: '14',
         },
-        // useBuiltIns: 'entry', // enable polyfills
-        // corejs: {
-        //   version: 3,
-        //   proposals: true,
-        // }, // Enable core-js and proposals
       },
     ],
   ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,11 +5,17 @@ module.exports = {
       '@babel/preset-env',
       {
         debug: false, // log babel preset-env config
-        useBuiltIns: 'entry', // enable polyfills
-        corejs: {
-          version: 3,
-          proposals: true,
-        }, // Enable core-js and proposals
+        targets: {
+          edge: '18',
+          firefox: '80',
+          chrome: '85',
+          safari: '14',
+        },
+        // useBuiltIns: 'entry', // enable polyfills
+        // corejs: {
+        //   version: 3,
+        //   proposals: true,
+        // }, // Enable core-js and proposals
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/API.ts
+++ b/src/API.ts
@@ -17,11 +17,12 @@ import {
   PenumbraTextOrURI,
   PenumbraWorkerAPI,
   RemoteResource,
+  ZipOptions,
 } from './types';
+import { PenumbraZipWriter } from './zip';
 import { blobCache, intoStreamOnlyOnce, isViewableText } from './utils';
 import { getWorker, setWorkerLocation } from './workers';
 import { supported } from './ua-support';
-import { saveZip } from './zip';
 
 const resolver = document.createElementNS(
   'http://www.w3.org/1999/xhtml',
@@ -138,6 +139,16 @@ const MAX_ALLOWED_SIZE_MAIN_THREAD = 16 * 1024 * 1024; // 16 MiB
 
 const isNumber = (number: unknown): number is number =>
   !isNaN(number as number);
+
+/**
+ * Zip files retrieved by Penumbra
+ *
+ * @param options - ZipOptions
+ * @returns PenumbraZipWriter class instance
+ */
+function saveZip(options?: ZipOptions): PenumbraZipWriter {
+  return new PenumbraZipWriter(options);
+}
 
 /**
  * Save files retrieved by Penumbra

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -429,8 +429,14 @@ const onReady = async (
         const closeSize = await writer.close();
         const size = await writer.getSize();
         const expectedSize = 270826;
-        console.log(size === closeSize, 'writer.close() size matches writer.getSize()');
-        console.log(size === expectedSize, `expected zip size (actual: ${size})`);
+        console.log(
+          size === closeSize,
+          'writer.close() size matches writer.getSize()',
+        );
+        console.log(
+          size === expectedSize,
+          `expected zip size (actual: ${size})`,
+        );
 
         return size === expectedSize;
       },

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -311,7 +311,7 @@ const onReady = async (
       },
     ],
     [
-      'penumbra.saveZip({ saveBuffer: true }) (zip hash checking)',
+      'penumbra.saveZip({ saveBuffer: true }) (getBuffer(), getSize() and auto-renaming)',
       async () =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise(async (resolve) => {
@@ -388,7 +388,13 @@ const onReady = async (
           const zipBuffer = await writer.getBuffer();
           const zipHash = await hash('SHA-256', zipBuffer);
           console.log('zip hash:', zipHash);
-          resolve(expectedReferenceHashes.includes(zipHash.toLowerCase()));
+          const size = await writer.getSize();
+          const expectedSize = 2622;
+          console.log(`zip size: ${size} (expected ${expectedSize})`);
+          resolve(
+            expectedReferenceHashes.includes(zipHash.toLowerCase()) &&
+              size === expectedSize,
+          );
         }),
     ],
     [

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -398,7 +398,7 @@ const onReady = async (
         }),
     ],
     [
-      'penumbra.saveZip() (completion tracking only)',
+      'penumbra.saveZip() (completion & size tracking only)',
       async () => {
         const files = [
           {
@@ -425,8 +425,14 @@ const onReady = async (
         ];
         const writer = penumbra.saveZip();
         await writer.write(...(await penumbra.get(...files)));
-        await writer.close();
-        return true;
+
+        const closeSize = await writer.close();
+        const size = await writer.getSize();
+        const expectedSize = 270826;
+        console.log(size === closeSize, 'writer.close() size matches writer.getSize()');
+        console.log(size === expectedSize, `expected zip size (actual: ${size})`);
+
+        return size === expectedSize;
       },
     ],
   );

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -315,57 +315,13 @@ const onReady = async (
       async () =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise(async (resolve) => {
-          const files = await penumbra.get(
-            {
-              url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-              path: 'test/NYT.txt',
-              mimetype: 'text/plain',
-              decryptionOptions: {
-                key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-                iv: '6lNU+2vxJw6SFgse',
-                authTag: 'gadZhS1QozjEmfmHLblzbg==',
-              },
-              // for hash consistency
-              lastModified: new Date(0),
-            },
-            {
-              url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-              path: 'test/NYT.txt',
-              mimetype: 'text/plain',
-              decryptionOptions: {
-                key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-                iv: '6lNU+2vxJw6SFgse',
-                authTag: 'gadZhS1QozjEmfmHLblzbg==',
-              },
-              // for hash consistency
-              lastModified: new Date(0),
-            },
-            {
-              url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-              path: 'test/NYT.txt',
-              mimetype: 'text/plain',
-              decryptionOptions: {
-                key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-                iv: '6lNU+2vxJw6SFgse',
-                authTag: 'gadZhS1QozjEmfmHLblzbg==',
-              },
-              // for hash consistency
-              lastModified: new Date(0),
-            },
-          );
           const expectedReferenceHashes = [
-            '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
-            '2b8c82efb241668778c56a7bd9f8f6da389149ba7607f5249c88618bca70f017',
+            '318e197f7df584c339ec6d06490eb9cb3cdbb41c218809690d39d70d79dff48f',
           ];
           let progressEventFiredAndWorking = false;
           let completeEventFired = false;
-          const expectedProgressProps = [
-            'percent',
-            'totalBytesRead',
-            'contentLength',
-          ];
+          const expectedProgressProps = ['percent', 'written', 'size'];
           const writer = penumbra.saveZip({
-            files,
             /** onProgress handler */
             onProgress(event) {
               progressEventFiredAndWorking = expectedProgressProps.every(
@@ -379,6 +335,68 @@ const onReady = async (
             allowDuplicates: true,
             saveBuffer: true,
           });
+          writer.write(
+            ...(await penumbra.get(
+              {
+                size: 874,
+                url:
+                  'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+                path: 'test/NYT.txt',
+                mimetype: 'text/plain',
+                decryptionOptions: {
+                  key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+                  iv: '6lNU+2vxJw6SFgse',
+                  authTag: 'gadZhS1QozjEmfmHLblzbg==',
+                },
+                // for hash consistency
+                lastModified: new Date(0),
+              },
+              {
+                size: 874,
+                url:
+                  'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+                path: 'test/NYT.txt',
+                mimetype: 'text/plain',
+                decryptionOptions: {
+                  key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+                  iv: '6lNU+2vxJw6SFgse',
+                  authTag: 'gadZhS1QozjEmfmHLblzbg==',
+                },
+                // for hash consistency
+                lastModified: new Date(0),
+              },
+            )),
+          );
+          writer.write(
+            ...(await penumbra.get(
+              {
+                url:
+                  'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+                path: 'test/NYT.txt',
+                mimetype: 'text/plain',
+                decryptionOptions: {
+                  key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+                  iv: '6lNU+2vxJw6SFgse',
+                  authTag: 'gadZhS1QozjEmfmHLblzbg==',
+                },
+                // for hash consistency
+                lastModified: new Date(0),
+              },
+              {
+                url:
+                  'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+                path: 'test/NYT.txt',
+                mimetype: 'text/plain',
+                decryptionOptions: {
+                  key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+                  iv: '6lNU+2vxJw6SFgse',
+                  authTag: 'gadZhS1QozjEmfmHLblzbg==',
+                },
+                // for hash consistency
+                lastModified: new Date(0),
+              },
+            )),
+          );
           await writer.close();
           console.log(
             progressEventFiredAndWorking,
@@ -389,8 +407,11 @@ const onReady = async (
           const zipHash = await hash('SHA-256', zipBuffer);
           console.log('zip hash:', zipHash);
           const size = await writer.getSize();
-          const expectedSize = 2622;
-          console.log(`zip size: ${size} (expected ${expectedSize})`);
+          const expectedSize = 3496;
+          console.log(
+            size === expectedSize,
+            `expected zip size (actual: ${size})`,
+          );
           resolve(
             expectedReferenceHashes.includes(zipHash.toLowerCase()) &&
               size === expectedSize,

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,23 @@
+/** Compression levels */
+export enum Compression {
+  /** No compression */
+  Store = 0,
+  /** Low compression */
+  Low = 1,
+  /** Medium compression */
+  Medium = 2,
+  /** High compression */
+  High = 3,
+}
+
+/** Penumbra user agent support level */
+export enum PenumbraSupportLevel {
+  /** Old browser where Penumbra does not work at all */
+  none = -0,
+  /** Modern browser where Penumbra is not yet supported */
+  possible = 0,
+  /** Modern browser where file size limit is low */
+  size_limited = 1,
+  /** Modern browser with full support */
+  full = 2,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import intoStream from 'into-stream';
 import penumbra from './API';
 import MOCK_API from './mock';
 import './transferHandlers/penumbra-events';
-import { PenumbraAPI, PenumbraSupportLevel } from './types';
+import { PenumbraAPI } from './types';
+import { PenumbraSupportLevel } from './enums';
 import { PenumbraEvent } from './event';
 
 export * from './types';

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -2,7 +2,8 @@
 /* tslint-disable no-empty */
 
 // local
-import { PenumbraAPI, PenumbraSupportLevel } from './types';
+import { PenumbraAPI } from './types';
+import { PenumbraSupportLevel } from './enums';
 import { PenumbraZipWriter } from './zip';
 
 const supported = (): PenumbraSupportLevel => -0;

--- a/src/penumbra.worker.js
+++ b/src/penumbra.worker.js
@@ -10,9 +10,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable class-methods-use-this */
 
-// external modules
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
 import { transfer, expose } from 'comlink';
 import { fromWritablePort, fromReadablePort } from 'remote-web-streams';
 

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -311,6 +311,7 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
   }
   const expectedReferenceHashes = [
     '318e197f7df584c339ec6d06490eb9cb3cdbb41c218809690d39d70d79dff48f',
+    '6cbf553053fcfe8b6c5e17313ef4383fcef4bc0cf3df48c904ed5e7b05af04a6',
   ];
   let progressEventFiredAndWorking = false;
   let completeEventFired = false;

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -6,9 +6,8 @@ import {
   PenumbraFile,
   PenumbraReady,
   ProgressEmit,
-  ZipProgressEmit,
-  PenumbraSupportLevel,
 } from '../types';
+import { PenumbraSupportLevel } from '../enums';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // import penumbra from '../API';

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -310,55 +310,15 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
     t.end();
     return;
   }
-  const files = await penumbra.get(
-    {
-      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-      path: 'test/NYT.txt',
-      mimetype: 'text/plain',
-      decryptionOptions: {
-        key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-        iv: '6lNU+2vxJw6SFgse',
-        authTag: 'gadZhS1QozjEmfmHLblzbg==',
-      },
-      // for hash consistency
-      lastModified: new Date(0),
-    },
-    {
-      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-      path: 'test/NYT.txt',
-      mimetype: 'text/plain',
-      decryptionOptions: {
-        key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-        iv: '6lNU+2vxJw6SFgse',
-        authTag: 'gadZhS1QozjEmfmHLblzbg==',
-      },
-      // for hash consistency
-      lastModified: new Date(0),
-    },
-    {
-      url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
-      path: 'test/NYT.txt',
-      mimetype: 'text/plain',
-      decryptionOptions: {
-        key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
-        iv: '6lNU+2vxJw6SFgse',
-        authTag: 'gadZhS1QozjEmfmHLblzbg==',
-      },
-      // for hash consistency
-      lastModified: new Date(0),
-    },
-  );
   const expectedReferenceHashes = [
-    '10ac213becf558c7467a438810ea6e6b7ca1c9766c736273a955555a808a21b2',
-    '2b8c82efb241668778c56a7bd9f8f6da389149ba7607f5249c88618bca70f017',
+    '318e197f7df584c339ec6d06490eb9cb3cdbb41c218809690d39d70d79dff48f',
   ];
   let progressEventFiredAndWorking = false;
   let completeEventFired = false;
-  const expectedProgressProps = ['percent', 'totalBytesRead', 'contentLength'];
+  const expectedProgressProps = ['percent', 'written', 'size'];
   const writer = penumbra.saveZip({
-    files,
     /** onProgress handler */
-    onProgress(event: ZipProgressEmit) {
+    onProgress(event) {
       progressEventFiredAndWorking = expectedProgressProps.every(
         (prop) => prop in event.detail,
       );
@@ -370,6 +330,64 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
     allowDuplicates: true,
     saveBuffer: true,
   });
+  writer.write(
+    ...(await penumbra.get(
+      {
+        size: 874,
+        url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+        path: 'test/NYT.txt',
+        mimetype: 'text/plain',
+        decryptionOptions: {
+          key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+          iv: '6lNU+2vxJw6SFgse',
+          authTag: 'gadZhS1QozjEmfmHLblzbg==',
+        },
+        // for hash consistency
+        lastModified: new Date(0),
+      },
+      {
+        size: 874,
+        url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+        path: 'test/NYT.txt',
+        mimetype: 'text/plain',
+        decryptionOptions: {
+          key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+          iv: '6lNU+2vxJw6SFgse',
+          authTag: 'gadZhS1QozjEmfmHLblzbg==',
+        },
+        // for hash consistency
+        lastModified: new Date(0),
+      },
+    )),
+  );
+  writer.write(
+    ...(await penumbra.get(
+      {
+        url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+        path: 'test/NYT.txt',
+        mimetype: 'text/plain',
+        decryptionOptions: {
+          key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+          iv: '6lNU+2vxJw6SFgse',
+          authTag: 'gadZhS1QozjEmfmHLblzbg==',
+        },
+        // for hash consistency
+        lastModified: new Date(0),
+      },
+      {
+        url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',
+        path: 'test/NYT.txt',
+        mimetype: 'text/plain',
+        decryptionOptions: {
+          key: 'vScyqmJKqGl73mJkuwm/zPBQk0wct9eQ5wPE8laGcWM=',
+          iv: '6lNU+2vxJw6SFgse',
+          authTag: 'gadZhS1QozjEmfmHLblzbg==',
+        },
+        // for hash consistency
+        lastModified: new Date(0),
+      },
+    )),
+  );
   await writer.close();
   t.ok(
     progressEventFiredAndWorking,

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -301,7 +301,7 @@ test('penumbra.encrypt() & penumbra.decrypt()', async (t) => {
   t.end();
 });
 
-test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)', async (t) => {
+test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-renaming', async (t) => {
   if (['Firefox', 'Safari'].includes(browserName)) {
     t.pass(
       // eslint-disable-next-line max-len
@@ -385,5 +385,11 @@ test('penumbra.saveZip({ saveBuffer: true }) (zip hash checking & auto-renaming)
     expectedReferenceHashes.includes(zipHash.toLowerCase()),
     `penumbra.saveZip() expected output hash (actual: ${zipHash})`,
   );
+
+  const size = await writer.getSize();
+  const expectedSize = 2622;
+
+  t.equals(size, expectedSize, 'expected zip size');
+
   t.end();
 });

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -405,7 +405,7 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
   );
 
   const size = await writer.getSize();
-  const expectedSize = 2622;
+  const expectedSize = 3496;
   t.equals(size, expectedSize, `expected zip size (actual: ${size})`);
 
   t.end();

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -388,7 +388,6 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
 
   const size = await writer.getSize();
   const expectedSize = 2622;
-
   t.equals(size, expectedSize, `expected zip size (actual: ${size})`);
 
   t.end();

--- a/src/tests/v4-api.test.ts
+++ b/src/tests/v4-api.test.ts
@@ -383,13 +383,13 @@ test('penumbra.saveZip({ saveBuffer: true }) - getBuffer(), getSize() and auto-r
   t.ok(zipHash, 'zip hash');
   t.ok(
     expectedReferenceHashes.includes(zipHash.toLowerCase()),
-    `penumbra.saveZip() expected output hash (actual: ${zipHash})`,
+    `expected zip hash (actual: ${zipHash})`,
   );
 
   const size = await writer.getSize();
   const expectedSize = 2622;
 
-  t.equals(size, expectedSize, 'expected zip size');
+  t.equals(size, expectedSize, `expected zip size (actual: ${size})`);
 
   t.end();
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export type RemoteResource = {
   requestInit?: RequestInit;
   /** Last modified date */
   lastModified?: Date;
+  /** Expected file size */
+  size?: number;
 };
 
 /** Penumbra file composition */
@@ -136,14 +138,12 @@ export type ProgressEmit = CustomEvent<ProgressDetails>;
  * Zip progress event details
  */
 export type ZipProgressDetails = {
-  /** The ID of the worker thread that is processing this job */
-  worker?: number | null;
   /** Percentage completed */
-  percent: number;
-  /** Total bytes read */
-  totalBytesRead: number;
-  /** Total number of bytes to read */
-  contentLength: number;
+  percent: number | null;
+  /** Total items written */
+  written: number;
+  /** Total number of expected items to write */
+  size: number | null;
 };
 
 /**
@@ -154,10 +154,7 @@ export type ZipProgressEmit = CustomEvent<ZipProgressDetails>;
 /**
  * Zip completion event details
  */
-export type ZipCompletionDetails = {
-  /** The ID of the worker thread that is processing this job */
-  worker?: number | null;
-};
+export type ZipCompletionDetails = {};
 
 /**
  * The type that is emitted as progress continues

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@
 
 // local
 import penumbra from './API';
+import { PenumbraSupportLevel } from './enums';
 import { PenumbraError } from './error';
 import { PenumbraZipWriter } from './zip';
 
@@ -20,18 +21,6 @@ export { PenumbraZipWriter } from './zip';
  * Make selected object keys defined by K optional in type T
  */
 type Optionalize<T, K extends keyof T> = Omit<T, K> & Partial<T>;
-
-/** Penumbra user agent support level */
-export enum PenumbraSupportLevel {
-  /** Old browser where Penumbra does not work at all */
-  none = -0,
-  /** Modern browser where Penumbra is not yet supported */
-  possible = 0,
-  /** Modern browser where file size limit is low */
-  size_limited = 1,
-  /** Modern browser with full support */
-  full = 2,
-}
 
 /**
  * penumbra.encrypt() encryption options config (buffers or base64-encoded strings)

--- a/src/ua-support.ts
+++ b/src/ua-support.ts
@@ -1,4 +1,4 @@
-import { PenumbraSupportLevel } from './types';
+import { PenumbraSupportLevel } from './enums';
 
 let supportLevel: PenumbraSupportLevel = PenumbraSupportLevel.none;
 

--- a/src/utils/emitZipProgress.ts
+++ b/src/utils/emitZipProgress.ts
@@ -11,17 +11,17 @@ import { PenumbraEvent } from '../event';
  */
 export default function emitZipProgress(
   writer: PenumbraZipWriter,
-  totalBytesRead: number,
-  contentLength: number,
+  written: number,
+  size: number | null,
 ): void {
   // Calculate the progress remaining
-  const percent = Math.round((totalBytesRead / contentLength) * 100);
+  const percent = size === null ? null : Math.round((written / size) * 100);
 
   const emitContent: Pick<ZipProgressEmit, 'detail'> = {
     detail: {
       percent,
-      totalBytesRead,
-      contentLength,
+      written,
+      size,
     },
   };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,10 +6,6 @@
  * @module utils
  */
 
-// Needed for generator support
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
-
 // local
 export { default as emitProgress } from './emitProgress';
 export { default as emitJobCompletion } from './emitJobCompletion';

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -177,9 +177,7 @@ export class PenumbraZipWriter extends EventTarget {
       if (sizeUnknown) {
         zip.byteSize = null;
       } else {
-        zip.byteSize += (files as { size: number }[])
-          .map(({ size }) => size)
-          .reduce((acc, val) => acc + val);
+        zip.byteSize += (sizes as number[]).reduce((acc, val) => acc + val);
       }
     }
     return sumWrites(

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -6,18 +6,7 @@ import mime from 'mime-types';
 import { PenumbraFile, ZipOptions } from './types';
 import emitZipProgress from './utils/emitZipProgress';
 import emitZipCompletion from './utils/emitZipCompletion';
-
-/** Compression levels */
-export enum Compression {
-  /** No compression */
-  Store = 0,
-  /** Low compression */
-  Low = 1,
-  /** Medium compression */
-  Medium = 2,
-  /** High compression */
-  High = 3,
-}
+import { Compression } from './enums';
 
 const isN = (value: unknown): value is number =>
   value !== null && !isNaN(value as number);
@@ -29,7 +18,9 @@ const sumWrites = async (writes: Promise<number>[]): Promise<number> => {
       .map(({ value }) => value)
       .reduce((acc, item) => acc + item, 0);
   }
-  const errors = results.filter(({ status }) => status === 'rejected') as PromiseRejectedResult[];
+  const errors = results.filter(
+    ({ status }) => status === 'rejected',
+  ) as PromiseRejectedResult[];
   // eslint-disable-next-line no-restricted-syntax
   for (const error of errors) {
     console.error(error.reason);
@@ -115,8 +106,10 @@ export class PenumbraZipWriter extends EventTarget {
     const { signal } = controller;
     signal.addEventListener(
       'abort',
-      () => { this.close() },
-      { once: true }
+      () => {
+        this.close();
+      },
+      { once: true },
     );
 
     // Auto-register onProgress & onComplete listeners
@@ -125,7 +118,9 @@ export class PenumbraZipWriter extends EventTarget {
     }
 
     if (typeof onComplete === 'function') {
-      this.addEventListener('complete', onComplete as EventListener, { once: true });
+      this.addEventListener('complete', onComplete as EventListener, {
+        once: true,
+      });
     }
 
     const saveStream = createWriteStream(
@@ -345,14 +340,4 @@ export class PenumbraZipWriter extends EventTarget {
   getFiles(): string[] {
     return [...this.files];
   }
-}
-
-/**
- * Zip files retrieved by Penumbra
- *
- * @param options - ZipOptions
- * @returns PenumbraZipWriter class instance
- */
-export function saveZip(options?: ZipOptions): PenumbraZipWriter {
-  return new PenumbraZipWriter(options);
 }


### PR DESCRIPTION
This PR upgrades the PenumbraZipWriter APIs to resolve the resultant size of their operations, and a getSize() helper has also been added.

This also fixes an issue where we would read from `value` in the zip.ts' `completionTrackerStream` when it could be `undefined`.

This PR should also improve size tracking consistency with async pagination.

## TODO

- [x] Refactor PenumbraZipWriter API to return eventual operation sizes
- [x] Implement `PenumbraZipWriter.getSize()` 
- [x] Add tests