### PR TITLE
Fix duplicate file warning text with `allowDuplicates=false` in `saveZip()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/API.ts
+++ b/src/API.ts
@@ -20,7 +20,12 @@ import {
   ZipOptions,
 } from './types';
 import { PenumbraZipWriter } from './zip';
-import { blobCache, intoStreamOnlyOnce, isNumber, isViewableText } from './utils';
+import {
+  blobCache,
+  intoStreamOnlyOnce,
+  isNumber,
+  isViewableText,
+} from './utils';
 import { getWorker, setWorkerLocation } from './workers';
 import { supported } from './ua-support';
 

--- a/src/API.ts
+++ b/src/API.ts
@@ -20,7 +20,7 @@ import {
   ZipOptions,
 } from './types';
 import { PenumbraZipWriter } from './zip';
-import { blobCache, intoStreamOnlyOnce, isViewableText } from './utils';
+import { blobCache, intoStreamOnlyOnce, isNumber, isViewableText } from './utils';
 import { getWorker, setWorkerLocation } from './workers';
 import { supported } from './ua-support';
 
@@ -136,9 +136,6 @@ const DEFAULT_FILENAME = 'download';
 const DEFAULT_MIME_TYPE = 'application/octet-stream';
 /** Maximum allowed resource size for encrypt/decrypt on the main thread */
 const MAX_ALLOWED_SIZE_MAIN_THREAD = 16 * 1024 * 1024; // 16 MiB
-
-const isNumber = (number: unknown): number is number =>
-  !isNaN(number as number);
 
 /**
  * Zip files retrieved by Penumbra

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,3 +19,4 @@ export { default as toBuff } from './toBuff';
 export { default as blobCache } from './blobCache';
 export { default as isViewableText } from './isViewableText';
 export { default as intoStreamOnlyOnce } from './intoStreamOnlyOnce';
+export { default as isNumber } from './isNumber';

--- a/src/utils/isNumber.ts
+++ b/src/utils/isNumber.ts
@@ -1,0 +1,4 @@
+const isNumber = (value: unknown): value is number =>
+  value !== null && !isNaN(value as number);
+
+export default isNumber;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -4,12 +4,8 @@ import { Writer } from '@transcend-io/conflux';
 import { createWriteStream } from 'streamsaver';
 import mime from 'mime-types';
 import { PenumbraFile, ZipOptions } from './types';
-import emitZipProgress from './utils/emitZipProgress';
-import emitZipCompletion from './utils/emitZipCompletion';
+import { isNumber, emitZipProgress, emitZipCompletion } from './utils';
 import { Compression } from './enums';
-
-const isN = (value: unknown): value is number =>
-  value !== null && !isNaN(value as number);
 
 const sumWrites = async (writes: Promise<number>[]): Promise<number> => {
   const results = await allSettled<Promise<number>[]>(writes);
@@ -98,7 +94,7 @@ export class PenumbraZipWriter extends EventTarget {
       );
     }
 
-    if (isN(size)) {
+    if (isNumber(size)) {
       this.byteSize = size;
     }
     this.allowDuplicates = allowDuplicates;
@@ -167,7 +163,7 @@ export class PenumbraZipWriter extends EventTarget {
 
     // Add file sizes to total zip size
     const sizes = files.map(({ size }) => size);
-    const totalWriteSize = sizes.every((size) => isN(size))
+    const totalWriteSize = sizes.every((size) => isNumber(size))
       ? (sizes as number[]).reduce((acc, val) => acc + val, 0)
       : null;
     if (zip.byteSize !== null) {
@@ -214,9 +210,9 @@ export class PenumbraZipWriter extends EventTarget {
             filePath = `${filename} (${i})${extension}`;
             const warning = `penumbra.saveZip(): Duplicate file ${JSON.stringify(
               dupe,
-            )} renamed to ${JSON.stringify(filePath)}`;
+            )}`;
             if (zip.allowDuplicates) {
-              console.warn(warning);
+              console.warn(`${warning} renamed to ${JSON.stringify(filePath)}`);
             } else {
               zip.abort();
               throw new Error(warning);


### PR DESCRIPTION
The previous warning indicated that duplicate files would be renamed even when `allowDuplicates=false`. This PR fixes it so that the warning text is now affected by `allowDuplicates`. I also cleaned up some imports in zip.ts and API.ts.