### PR TITLE
Preload resources with cross-origin fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "description": "Crypto streams for the browser.",
   "main": "build/penumbra.js",
   "types": "ts-build/src/index.d.ts",
@@ -41,6 +41,9 @@
   },
   "keywords": [
     "browser",
+    "crypto",
+    "worker",
+    "encryption",
     "decryption",
     "stream",
     "client"

--- a/src/resource-hints.ts
+++ b/src/resource-hints.ts
@@ -27,16 +27,23 @@ const nooper = (): CleanupResourceHints => (): void => {
  * A helper function that creates a set resource hints
  *
  * @param urls - The urls to add the resource hint to
+ * @param rel - Type of link rel that is being being hinted
+ * @param fetch - Request resource as a cross-origin fetch
  * @returns A function removing the resource hints
  */
 export function createResourceHintHelper(
   urls: string[],
   rel: LinkRel,
+  fetch = false,
 ): CleanupResourceHints {
   if (self.document) {
     const links = urls.map((href) => {
       const link = document.createElement('link');
       link.rel = rel;
+      if (fetch) {
+        link.as = 'fetch';
+        link.crossOrigin = 'use-credentials';
+      }
       link.href = href;
       document.head.appendChild(link);
       return link;
@@ -71,5 +78,6 @@ export function preload(...resources: RemoteResource[]): () => void {
   return createResourceHintHelper(
     resources.map(({ url }) => url),
     'preload',
+    true,
   );
 }

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -282,7 +282,9 @@ test('penumbra.preconnect()', async (t) => {
 
 test('penumbra.preload()', async (t) => {
   const measurePreloads = () =>
-    document.querySelectorAll('link[rel="preload"]').length;
+    document.querySelectorAll(
+      'link[rel="preload"][as="fetch"][crossorigin="use-credentials"]',
+    ).length;
   const start = measurePreloads();
   const cleanup = penumbra.preload({
     url: 'https://s3-us-west-2.amazonaws.com/bencmbrook/NYT.txt.enc',


### PR DESCRIPTION
This PR makes `penumbra.preload()` request resources with cross-origin fetch, so we don't end up double-fetching preloaded resources.