### PR TITLE
Safari 14.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@
 
 ## Compatibility
 
-|          | .decrypt | .encrypt | .saveZip |
-| -------- | -------: | -------: | -------: |
-| Chrome   |       ✅ |       ✅ |       ✅ |
-| Edge >18 |       ✅ |       ✅ |       ✅ |
-| Safari   |       🐢 |       🐢 |       🟡 |
-| Firefox  |       🐢 |       🐢 |       🟡 |
-| Edge 18  |       ❌ |       ❌ |       ❌ |
+|              | .decrypt | .encrypt | .saveZip |
+| ------------ | -------: | -------: | -------: |
+| Chrome       |       ✅ |       ✅ |       ✅ |
+| Edge >18     |       ✅ |       ✅ |       ✅ |
+| Safari ≥14.1 |       ✅ |       ✅ |       ✅ |
+| Safari <14.1 |       🐢 |       🐢 |       🟡 |
+| Firefox      |       🐢 |       🐢 |       🟡 |
+| Edge 18      |       ❌ |       ❌ |       ❌ |
 
 ✅ = Full support with workers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Crypto streams for the browser.",
   "main": "build/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -124,11 +124,11 @@ function reDispatchEvent(event: Event): void {
 
 // Set data-worker-limit to limit the maximum number of Penumbra workers
 const WORKER_LIMIT = +(script.workerLimit || 16);
-const nativeHwConcurrency = navigator.hardwareConcurrency;
+const { hardwareConcurrency } = navigator;
 // Get available processor threads
-const availConcurrency = nativeHwConcurrency
+const availConcurrency = hardwareConcurrency
   ? // Reserve one thread (if hwConcurrency is supported) for UI renderer to prevent jank
-    nativeHwConcurrency - 1
+    hardwareConcurrency - 1
   : 4;
 const maxConcurrency =
   availConcurrency > WORKER_LIMIT ? WORKER_LIMIT : availConcurrency;

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -124,11 +124,12 @@ function reDispatchEvent(event: Event): void {
 
 // Set data-worker-limit to limit the maximum number of Penumbra workers
 const WORKER_LIMIT = +(script.workerLimit || 16);
+const nativeHwConcurrency = navigator.hardwareConcurrency;
 // Get available processor threads
-const availConcurrency = // Default to 4 threads if nav.hwConcurrency isn't supported
-  (navigator.hardwareConcurrency || 5) -
-  // Reserve one thread for UI renderer to prevent jank
-  1;
+const availConcurrency = nativeHwConcurrency
+  ? // Reserve one thread (if hwConcurrency is supported) for UI renderer to prevent jank
+    nativeHwConcurrency - 1
+  : 4;
 const maxConcurrency =
   availConcurrency > WORKER_LIMIT ? WORKER_LIMIT : availConcurrency;
 const workers: PenumbraWorker[] = [];

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -126,7 +126,7 @@ function reDispatchEvent(event: Event): void {
 const WORKER_LIMIT = +(script.workerLimit || 16);
 // Get available processor threads
 const availConcurrency = // Default to 4 threads if nav.hwConcurrency isn't supported
-  (navigator.hardwareConcurrency || 4) -
+  (navigator.hardwareConcurrency || 5) -
   // Reserve one thread for UI renderer to prevent jank
   1;
 const maxConcurrency =


### PR DESCRIPTION
This PR notes that Safari 14.1 fully supports Penumbra. Safari 14.1 is currently only available as a technology preview.

I also changed the worker pool logic to default to at least 4 workers when `navigator.hardwareConcurrency` is not supported. This ensures that Safari uses at least 4 threads for decryption. Alternatively we could use [Core Estimator](https://oswg.oftn.org/projects/core-estimator/demo/) to get the real core count, at the cost of ~0.3s additional startup time (only on Safari).

@bencmbrook @michaelfarrell76 What are your thoughts on using Core Estimator for improved throughput in Safari?