### PR TITLE
Better build scripts for demo/example. Dont write to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test:local:rebuild": "yarn && karma start karma.local.js",
     "test:browserstack": "karma start karma.browserstack.js",
     "####### Build #######": "",
-    "clean": "rimraf build && rimraf coverage",
+    "clean": "rimraf dist && rimraf ts-build && rimraf coverage",
     "build": "yarn clean && mkdir -p dist && webpack --config webpack.prod.js && tsc",
-    "build:example": "rimraf example/build && yarn build && mkdir -p example/build && cp -a example/. dist/ && cp -a dist/. example/build/",
-    "build:demo": "rimraf demo/build && yarn build && mkdir -p demo/build && cp -a demo/. dist/ && cp -a dist/. demo/build/",
+    "build:example": "rimraf example/build && yarn build && mkdir -p example/build && cp example/*.* example/build/ && cp -a dist/. example/build/",
+    "build:demo": "rimraf demo/build && yarn build && mkdir -p demo/build && cp demo/*.* demo/build/ && cp -a dist/. demo/build/",
     "webpack:watch": "yarn clean && webpack --config webpack.dev.js --watch"
   },
   "repository": {


### PR DESCRIPTION
Improves build scripts for demo/example. No longer writes to the `dist` folder

## Related Issues

- _[none]_

## Public Changelog

_[none]_

## Security Implications

_[none]_
