### PR TITLE
Fix potential race condition with `PenumbraZipWriter.close()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Crypto streams for the browser.",
   "main": "dist/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -318,11 +318,11 @@ export class PenumbraZipWriter extends EventTarget {
    *
    * @returns Total observed zip size in bytes after close completes
    */
-  close(): Promise<number> {
-    const size = this.getSize();
+  async close(): Promise<number> {
+    const size = await this.getSize();
     if (!this.closed) {
-      this.writer.close();
       this.closed = true;
+      this.writer.close();
     }
     return size;
   }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -321,8 +321,8 @@ export class PenumbraZipWriter extends EventTarget {
   async close(): Promise<number> {
     const size = await this.getSize();
     if (!this.closed) {
-      this.closed = true;
       this.writer.close();
+      this.closed = true;
     }
     return size;
   }


### PR DESCRIPTION
It appears that PenumbraZipWriter.close() might not wait for all writes to finish. I tweaked the function to explicitly await on this.getSize() before this.writer.close() is called.

I think this hasn't caused issues yet because we aren't awaiting `writer.close()` (intentional)

## Related Issues

- _[none]_

## Public Changelog

_[none]_

## Security Implications

_[none]_
