### PR TITLE
Make `PenumbraZipWriter.byteSize` public & writable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Crypto streams for the browser.",
   "main": "dist/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Crypto streams for the browser.",
   "main": "dist/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -318,11 +318,11 @@ export class PenumbraZipWriter extends EventTarget {
    *
    * @returns Total observed zip size in bytes after close completes
    */
-  close(): Promise<number> {
-    const size = this.getSize();
+  async close(): Promise<number> {
+    const size = await this.getSize();
     if (!this.closed) {
-      this.writer.close();
       this.closed = true;
+      this.writer.close();
     }
     return size;
   }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -321,8 +321,8 @@ export class PenumbraZipWriter extends EventTarget {
   async close(): Promise<number> {
     const size = await this.getSize();
     if (!this.closed) {
-      this.closed = true;
       this.writer.close();
+      this.closed = true;
     }
     return size;
   }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -81,7 +81,7 @@ export class PenumbraZipWriter extends EventTarget {
   private completedWrites = 0;
 
   /** Total zip archive size */
-  private byteSize: number | null = 0;
+  public byteSize: number | null = 0;
 
   /** Current zip archive size */
   private bytesWritten = 0;


### PR DESCRIPTION
This makes it easier for paginated writing loops to dynamically update a zip writer's total byteSize during pagination.

e.g.


```js
const writer = penumbra.saveZip();
for (const page of pages) {
  writer.byteSize += page.size;
  writer.write(...page.files);
}
```

## Related Issues

- _[none]_

## Public Changelog

_[none]_

## Security Implications

_[none]_
