### PR TITLE
[WIP] Add documentation and utility for importing native Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,35 @@ type RemoteResource = {
 };
 ```
 
+### PenumbraFile
+
+Encryption & decryption APIs work on PenumbraFile descriptors to that store file data and metadata.
+
+```ts
+/** Penumbra file composition */
+export interface PenumbraFile extends Omit<RemoteResource, 'url'> {
+  /** Backing stream */
+  stream: ReadableStream;
+  /** File size (if backed by a ReadableStream) */
+  size?: number;
+  /** Optional ID for tracking encryption completion */
+  id?: number | string;
+  /** Last modified date */
+  lastModified?: Date;
+}
+```
+
+HTML File and FileList descriptors can be converted for use with penumbra APIs through `penumbra.importFile(files: File, path?: string)` and can be used to encrypt and decrypt files.
+
+```ts
+// Automatically encrypt & save files selected in a file selector
+const fileSelector = document.getElementById('file-selector');
+fileSelector.addEventListener('change', (event) => {
+  const file = penumbra.importFile(event.target.files[0]);
+  penumbra.encrypt(file).then(penumbra.save);
+});
+```
+
 ### .get
 
 Fetch and decrypt remote files.
@@ -346,7 +375,7 @@ await writer.close();
 
 ### .setWorkerLocation
 
-Configure the location of Penumbra's worker threads.
+Configure the location of Penumbra's worker threads. This should be called before any other Penumbra methods and is not currently reconfigurable post-initialization.
 
 ```ts
 penumbra.setWorkerLocation(location: WorkerLocationOptions | string): Promise<void>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "Crypto streams for the browser.",
   "main": "dist/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/API.ts
+++ b/src/API.ts
@@ -581,9 +581,24 @@ function getTextOrURI(files: PenumbraFile[]): Promise<PenumbraTextOrURI>[] {
   });
 }
 
+/**
+ * Convert HTML File object to a PenumbraFile
+ *
+ * @param file - File to import
+ * @returns PenumbraFile
+ */
+async function importFile(file: File): Promise<PenumbraFile> {
+  return {
+    stream: new Response(await file.arrayBuffer()).body as ReadableStream,
+    size: file.size,
+    mimetype: file.type,
+  };
+}
+
 const penumbra = {
   preconnect,
   preload,
+  importFile,
   get,
   encrypt,
   decrypt,


### PR DESCRIPTION
This PR adds a `penumbra.importFile(file: File): Promise<PenumbraFile>` utility for easier interoperability with `File`s from native file selectors.

## Related Issues

- Closes https://github.com/transcend-io/penumbra/issues/230

## Public Changelog

_[none]_

## Security Implications

_[none]_
