### PR TITLE
Improve Penumbra worker init reliability

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -418,6 +418,7 @@ const onReady = async (
               },
             )),
           );
+
           writer.write(
             ...(await penumbra.get(
               {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/penumbra",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Crypto streams for the browser.",
   "main": "dist/main.penumbra.js",
   "types": "ts-build/src/index.d.ts",

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -176,7 +176,7 @@ function getFreeWorker(): PenumbraWorker {
     throw new Error('No Penumbra workers available.');
   }
 
-  // Poll for any available free workers or create a new one
+  // Poll for any available free workers
   const freeWorker = workers.find(({ busy }) => !busy);
 
   // return any free worker or a random one if all are busy


### PR DESCRIPTION
This PR prevents `getFreeWorker()` from setting `busy = true` whenever no workers are available and also fixes `setWorkerLocation()` when called post-init to correctly re-init worker threads.

## Related Issues

- https://transcend.height.app/T-17238

## Public Changelog

_[none]_

## Security Implications

_[none]_
